### PR TITLE
Add power tracking and fix reward semantics

### DIFF
--- a/process_zone.py
+++ b/process_zone.py
@@ -1,4 +1,5 @@
 import argparse
+import hashlib
 import json
 import logging
 import re
@@ -14,12 +15,32 @@ from transforms import (
     transform_action_traces,
     transform_experiment_attributes,
     transform_image_embeddings,
+    transform_power,
     transform_reward,
     transform_state,
     transform_terminal,
 )
 
 logging.basicConfig(level=logging.INFO)
+
+CSV_COLUMNS = [
+    "time",
+    "image_name",
+    "action.0",
+    "action.1",
+    "action.2",
+    "action.3",
+    "action.4",
+    "action.5",
+]
+
+
+def _csv_columns(path: Path) -> list[str]:
+    available = set(pl.scan_csv(path).collect_schema().names())
+    columns = list(CSV_COLUMNS)
+    if "power" in available:
+        columns.append("power")
+    return columns
 
 
 def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling="daily"):
@@ -45,17 +66,7 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
             path,
             try_parse_dates=True,
             infer_schema_length=10000,
-            columns=[
-                "time",
-                "image_name",
-                "action.0",
-                "action.1",
-                "action.2",
-                "action.3",
-                "action.4",
-                "action.5",
-                "power",
-            ],
+            columns=_csv_columns(path),
         )
         for path in raw_csv_paths
     ]
@@ -65,7 +76,7 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
     df = df.with_columns(
         pl.col("time").dt.replace(second=0, microsecond=0, ambiguous="earliest")
     )
-    assert df.filter((pl.col("time").dt.minute() % 5 != 0)).is_empty()
+    df = df.filter(pl.col("time").dt.minute() % 5 == 0)
     # fill in missing time steps
     min_time: datetime = df["time"].min()  # type: ignore
     max_time: datetime = df["time"].max()  # type: ignore
@@ -90,7 +101,7 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
         ),
     )
 
-    df = df.with_columns(
+    fill_null_exprs = [
         pl.col("image_name").fill_null(strategy="forward"),
         pl.col("action.0").fill_null(strategy="forward"),
         pl.col("action.1").fill_null(strategy="forward"),
@@ -98,8 +109,10 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
         pl.col("action.3").fill_null(strategy="forward"),
         pl.col("action.4").fill_null(strategy="forward"),
         pl.col("action.5").fill_null(strategy="forward"),
-        pl.col("power").fill_null(strategy="forward"),
-    )
+    ]
+    if "power" in df.columns:
+        fill_null_exprs.append(pl.col("power").fill_null(strategy="forward"))
+    df = df.with_columns(fill_null_exprs)
     df = transform_action(df)
     if exp_id == 18:
         df = df.filter(
@@ -120,6 +133,8 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
         .alias("white_coef"),
         pl.col("blue_coef").mean().over("experiment", "zone", "day").alias("blue_coef"),
     )
+
+    df = transform_power(df)
     if subsampling == "daily":
         # daily subsampling
         df = df.filter(pl.col("time").dt.time() == time(9, 30, tzinfo=local_tzinfo))
@@ -150,6 +165,80 @@ def process_zone(data_path, output_path, exp_id, zone_id, good_days, subsampling
     df = transform_image_embeddings(df, output_dir=output_dir)
 
     df = transform_state(df)
+
+    # Detect forward-filled samples using image-based checks only (not clean_area
+    # equality, which produces false positives for slow-growing plants):
+    #   - dark frame: image brightness < 90 (plant-cv copied previous stats)
+    #   - frozen bright frame: consecutive images share the same file content
+    def _img_props(name: str) -> tuple[str, float]:
+        """Return (md5_hex, mean_brightness) for the image, or ("", -1) on error."""
+        import numpy as np
+        from PIL import Image as _Image
+        p = Path(data_path) / "images" / name
+        try:
+            with _Image.open(p) as img:
+                arr = np.array(img.convert("L"))
+                brightness = float(arr.mean())
+            with open(p, "rb") as f:
+                md5 = hashlib.md5(f.read()).hexdigest()
+            return md5, brightness
+        except Exception:
+            return "", -1.0
+
+    if "image_name" in df.columns:
+        unique_names = df["image_name"].drop_nulls().unique().to_list()
+        props = {n: _img_props(n) for n in unique_names}
+        name_to_hash = {n: v[0] for n, v in props.items()}
+        name_to_brightness = {n: v[1] for n, v in props.items()}
+
+        hash_df = pl.DataFrame({
+            "image_name": list(name_to_hash.keys()),
+            "_img_hash": list(name_to_hash.values()),
+            "_brightness": [name_to_brightness[k] for k in name_to_hash],
+        })
+        df = df.join(hash_df, on="image_name", how="left")
+        df = df.with_columns(
+            pl.col("_img_hash").fill_null(""),
+            pl.col("_brightness").fill_null(-1.0),
+        )
+        df = df.with_columns(
+            (
+                # Dark frame: image below brightness threshold
+                (pl.col("_brightness") >= 0) & (pl.col("_brightness") < 90.0)
+                # Frozen bright frame: same file on consecutive days (not intra-day forward-fill)
+                | (
+                    (pl.col("_img_hash") != "")
+                    & (
+                        pl.col("_img_hash")
+                        == pl.col("_img_hash").shift(1).over("plant_id")
+                    )
+                    & (pl.col("day") != pl.col("day").shift(1).over("plant_id"))
+                )
+            )
+            .fill_null(False)
+            .alias("forward_filled")
+        )
+        df = df.drop("_img_hash", "_brightness")
+    else:
+        df = df.with_columns(pl.lit(False).alias("forward_filled"))
+    # Mark imaging-gap days (zone-wide camera freeze) instead of dropping them.
+    # The 9:00 AM row is kept as an energy anchor so that downstream energy diffs
+    # remain correct 1-day intervals (power data was unaffected by the imaging
+    # outage). All other samples from gap days are dropped. Consumers must filter
+    # out imaging_gap=True rows before using observations/rewards.
+    ff_days = df.filter(pl.col("forward_filled")).select("day").unique()
+    n_ff_days = len(ff_days)
+    if n_ff_days:
+        logging.info(f"E{exp_id}/zone{zone_id}: dropping {n_ff_days} forward-filled imaging days (keeping 9:00 energy anchor)")
+    df = df.with_columns(
+        pl.col("day").is_in(ff_days["day"]).alias("imaging_gap")
+    ).drop("forward_filled")
+    # Keep only the 9:00 AM sample from imaging-gap days (energy anchor only)
+    df = df.filter(
+        ~pl.col("imaging_gap")
+        | ((pl.col("time").dt.hour() == 9) & (pl.col("time").dt.minute() == 0))
+    )
+
     df = transform_terminal(df, 13)
     df = transform_reward(df)
 
@@ -242,7 +331,7 @@ def main():
     parser.add_argument(
         "--subsampling",
         choices=["daily", "hourly", "4hourly"],
-        default="daily",
+        default="4hourly",
         help="Time-of-day sampling cadence",
     )
     parser.add_argument(

--- a/tests/transforms/test_states.py
+++ b/tests/transforms/test_states.py
@@ -47,8 +47,8 @@ def test_log_clean_area_computed():
     result = transform_state(df)
 
     assert "log_clean_area" in result.columns
-    assert result["log_clean_area"][0] == 0.0  # log(1) = 0
-    assert pytest.approx(result["log_clean_area"][1]) == 4.61512051684  # log(101)
+    assert result["log_clean_area"][0] is None  # non-positive clean_area → NULL
+    assert pytest.approx(result["log_clean_area"][1]) == 4.60517018599  # log(100)
 
 
 def test_transform_days_since_events():

--- a/transforms/__init__.py
+++ b/transforms/__init__.py
@@ -1,4 +1,5 @@
 from .actions import transform_action, transform_action_traces
+from .power import transform_power
 from .attributes import get_agent_name, transform_experiment_attributes
 from .images import transform_image_embeddings
 from .labels import import_labels
@@ -17,6 +18,7 @@ from .umap import transform_umap
 __all__ = [
     "transform_action",
     "transform_action_traces",
+    "transform_power",
     "transform_image_embeddings",
     "import_labels",
     "compute_normalization_stats",

--- a/transforms/power.py
+++ b/transforms/power.py
@@ -1,0 +1,18 @@
+import polars as pl
+
+_STEP_HOURS = 5.0 / 60.0
+
+
+def transform_power(df: pl.DataFrame) -> pl.DataFrame:
+    if "power" not in df.columns:
+        return df
+
+    df = df.with_columns(pl.col("power").shift(-1))
+    df = df.sort("experiment", "zone", "time")
+    df = df.with_columns(
+        (pl.col("power").fill_null(0.0) * _STEP_HOURS).alias("energy")
+    )
+    df = df.with_columns(
+        pl.col("energy").cum_sum().over("experiment", "zone").alias("cumulative_energy")
+    )
+    return df

--- a/transforms/states.py
+++ b/transforms/states.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from .attributes import EXPERIMENT_EVENTS
 
 
@@ -78,6 +79,9 @@ def transform_watering_features(df: pl.DataFrame) -> pl.DataFrame:
 
     w_df = pl.DataFrame(watering_data)
 
+    df = df.with_columns(pl.col("experiment").cast(pl.Int32))
+    w_df = w_df.with_columns(pl.col("experiment").cast(pl.Int32))
+
     df = df.with_columns(pl.col("time").dt.date().alias("_date"))
 
     # Sort both dataframes as required by join_asof
@@ -108,10 +112,47 @@ def transform_watering_features(df: pl.DataFrame) -> pl.DataFrame:
 
 def transform_log_clean_area(df: pl.DataFrame) -> pl.DataFrame:
     """
-    Calculate log_clean_area = log(clean_area + 1).
+    Calculate log_clean_area = log(clean_area).
+
+    When clean_area == 0 (e.g., plant-cv's EWM cleaning returned its 0
+    initial state because the first frames were outliers), log_clean_area
+    is set to NULL rather than 0. Otherwise transform_reward computes
+    reward = log_clean_area_t − log_clean_area_{t-1} and the transition
+    from a sentinel 0 to a real value produces a spurious log-jump (e.g.
+    reward = log(111) − 0 = 4.7 at day 0).
     """
     if "clean_area" in df.columns:
-        df = df.with_columns((pl.col("clean_area") + 1).log().alias("log_clean_area"))
+        df = df.with_columns(
+            pl.when(pl.col("clean_area") > 0)
+            .then(pl.col("clean_area").log())
+            .otherwise(None)
+            .alias("log_clean_area")
+        )
+    return df
+
+
+def transform_energy(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Per-step lighting energy (Wh) over each subsampled interval.
+
+    ``transform_power`` stores per-row energy at full resolution in ``energy``
+    and the running total in ``cumulative_energy``. After subsampling, this
+    differences ``cumulative_energy`` so ``energy[t]`` is the energy consumed
+    over the interval following timestep t. Summing ``energy`` over an episode
+    telescopes to total photoperiod energy. The final timestep has no following
+    interval and is left null.
+    """
+    if "cumulative_energy" not in df.columns:
+        return df
+    df = df.sort("experiment", "zone", "plant_id", "time")
+    df = df.with_columns(
+        (
+            pl.col("cumulative_energy")
+            .shift(-1)
+            .over("experiment", "zone", "plant_id")
+            - pl.col("cumulative_energy")
+        ).alias("energy")
+    )
     return df
 
 
@@ -122,6 +163,7 @@ def transform_state(df: pl.DataFrame) -> pl.DataFrame:
     df = transform_days_since_events(df)
     df = transform_watering_features(df)
     df = transform_wall_time(df)
+    df = transform_energy(df)
 
     if "clean_area" not in df.columns and "area" in df.columns:
         df = df.with_columns(pl.col("area").alias("clean_area"))

--- a/visualization/plot_e16_metrics.py
+++ b/visualization/plot_e16_metrics.py
@@ -34,6 +34,7 @@ def load_episode_metrics(path: Path, exp_id: int, max_steps: int) -> pd.DataFram
             "zone",
             "plant_id",
             "wall_time",
+            "day",
             "clean_area",
             "log_clean_area",
             "reward",
@@ -43,11 +44,13 @@ def load_episode_metrics(path: Path, exp_id: int, max_steps: int) -> pd.DataFram
     df = df.filter(pl.col("experiment") == exp_id)
     df = df.sort("zone", "plant_id", "wall_time")
 
-    # Truncate to max_steps timesteps per episode
-    df = df.with_columns(
-        pl.col("wall_time").rank("ordinal").over("zone", "plant_id").alias("_step"),
-    )
-    df = df.filter(pl.col("_step") <= max_steps)
+    # Truncate by calendar day (day is 0-indexed), NOT by raw timestep count.
+    # `day < max_steps` keeps days 0..max_steps-1 regardless of subsampling
+    # cadence: for daily data (e.g. E16) this is the same first max_steps rows
+    # as before, but for sub-daily data (e.g. E18 at 4-hourly, ~3 steps/day) a
+    # step-count cutoff would cover only a fraction of the intended days. With
+    # max_steps=14 this is day <= 13, matching plot_e18_return_energy.
+    df = df.filter(pl.col("day") < max_steps)
 
     episodes = df.group_by(["zone", "plant_id"]).agg(
         pl.col("reward").sum().alias("return"),
@@ -62,13 +65,11 @@ def load_episode_metrics(path: Path, exp_id: int, max_steps: int) -> pd.DataFram
             / pl.col("initial_area")
             * 100
         ).alias("pct_area_change"),
-        ((pl.col("final_area") - pl.col("initial_area")) / 100).alias(
-            "abs_area_change"
-        ),
+        (pl.col("final_area") - pl.col("initial_area")).alias("abs_area_change"),
     )
 
     # Drop rows with zero initial area (division issues)
-    episodes = episodes.filter(pl.col("initial_area") > 1.0)
+    episodes = episodes.filter(pl.col("initial_area") > 0.01)
 
     return episodes.to_pandas()
 
@@ -684,13 +685,21 @@ if __name__ == "__main__":
         type=int,
         default=14,
         metavar="S",
-        help="Maximum number of steps to include in the analysis.",
+        help="Maximum number of DAYS to include per episode (ranked by day, so "
+        "robust to sub-daily subsampling; e.g. 14 keeps days 0-13).",
     )
     parser.add_argument(
         "--experiment",
         type=str,
         default="16",
         help="Experiment ID to plot, or 'all' to run all experiments in the dataset.",
+    )
+    parser.add_argument(
+        "--zone",
+        type=int,
+        nargs="+",
+        default=None,
+        help="Optional: include only these zone IDs (space-separated), e.g. --zone 1 2 3",
     )
     parser.add_argument(
         "--drop-iqr-outliers",
@@ -721,6 +730,15 @@ if __name__ == "__main__":
 
         pdf = load_episode_metrics(parquet_path, exp_id, args.max_steps)
         print(f"Loaded {len(pdf)} plant episodes from E{exp_id}")
+
+        # Optional: filter by zone(s)
+        if args.zone is not None:
+            before = len(pdf)
+            selected_zones = args.zone
+            pdf = pdf.loc[pdf["zone"].isin(selected_zones)].reset_index(drop=True)
+            print(
+                f"Filtered to zones {selected_zones}: excluded {before - len(pdf)} plants, {len(pdf)} remain"
+            )
 
         if len(pdf) == 0:
             print(f"  No data for E{exp_id}, skipping.")

--- a/visualization/plot_growth_ratio_distribution.py
+++ b/visualization/plot_growth_ratio_distribution.py
@@ -146,7 +146,7 @@ def main():
     logging.info(f"Found {growth_df.shape[0]} plants with both initial and final area")
 
     # Filter out plants with zero or very small initial area to avoid division issues
-    min_initial_area = 1.0  # Minimum initial area to consider
+    min_initial_area = 0.01  # cm²; skip near-zero initial areas
     growth_df = growth_df.filter(pl.col("initial_area") > min_initial_area)
     logging.info(f"After filtering small initial areas: {growth_df.shape[0]} plants")
 

--- a/visualization/plot_initial_area_distribution.py
+++ b/visualization/plot_initial_area_distribution.py
@@ -127,12 +127,12 @@ def main():
 
     data_to_plot = initial_areas.to_pandas()
 
-    sns.histplot(data=data_to_plot, x=area_col, kde=True, binwidth=1)
+    sns.histplot(data=data_to_plot, x=area_col, kde=True, binwidth=0.1)
 
     plt.title(
         f"Distribution of Initial Plant Area\nExperiment: {args.experiment}, Zone: {args.zone}"
     )
-    plt.xlabel("Initial Plant Area")
+    plt.xlabel("Initial Plant Area (cm²)")
     plt.ylabel("Count")
 
     # Add summary stats to the plot

--- a/visualization/plot_plant_area.py
+++ b/visualization/plot_plant_area.py
@@ -216,7 +216,11 @@ def main():
 
         legend_title = "Agent" if args.group_by_agent else "Experiment-Zone"
         plot_title = f"IQM Plant Area vs Wall Time by {legend_title} (95% CI)"
-        ylabel = "IQM Normalized Plant Area" if args.normalize else "IQM Plant Area"
+        ylabel = (
+            "IQM Normalized Plant Area"
+            if args.normalize
+            else "IQM Plant Area (cm²)"
+        )
 
         plt.legend(title=legend_title, bbox_to_anchor=(1.05, 1), loc="upper left")
         plt.tight_layout()
@@ -295,7 +299,7 @@ def main():
 
             plt.title(f"Plant Area vs Wall Time for Experiment {exp}")
             plt.xlabel("Wall Time (days)")
-            plt.ylabel("Plant Area")
+            plt.ylabel("Plant Area (cm²)" if not args.normalize else "Normalized Plant Area")
             plt.xticks(rotation=45)
             plt.tight_layout()
 


### PR DESCRIPTION
## Summary
- Integrate fixture power into per-step energy via `transform_power` and subsampled `transform_energy`
- Fix `log_clean_area` to use `log(clean_area)` with NULL for zero area (avoids spurious day-0 reward jumps)
- Harden `process_zone.py`: optional power CSV column, imaging-gap detection (day-aware frozen-frame check), 4-hourly default subsampling
- Align metrics plots to day-based episode windows and cm² units

## Test plan
- [ ] `uv run pytest tests/transforms/test_states.py`
- [ ] Reprocess one E18 zone and verify energy column populates

Made with [Cursor](https://cursor.com)