### PR TITLE
E18 analysis scripts and energy-return plots

### DIFF
--- a/run_e18.py
+++ b/run_e18.py
@@ -21,9 +21,9 @@ def run_cmd(cmd: list[str], description: str) -> None:
 def main():
     root_dir = Path(__file__).resolve().parent
     parquet_path = "/data/plant-rl/offline/v27/mixed-v27.parquet"
-    zones = [1, 2, 3, 4, 5, 11]
-    max_steps_list = [2, 3, 4, 5, 6, 7, 8]
-    max_day = 8
+    zones = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    max_steps_list = [14]
+    max_day = 14
 
     # 1. Plot E18 Metrics
     print("=== Plotting E18 Metrics ===")
@@ -156,6 +156,8 @@ def main():
             parquet_path,
             "--out",
             "results/e18_return_energy.png",
+            "--out-schemas",
+            "results/e18_return_energy_schemas.png",
         ],
         "Plotting Return and Energy trade-off grouped by Agent for E18",
     )

--- a/scripts/create_anffany_v1.py
+++ b/scripts/create_anffany_v1.py
@@ -1,0 +1,95 @@
+"""Create anffany-v1.1.parquet from mixed-v27.parquet (E18 only)."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import polars as pl
+
+from config import VERSION
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+EXPERIMENT = 18
+
+DROP_COLUMNS = [
+    "action_coefficients",
+    "red_coef",
+    "white_coef",
+    "blue_coef",
+    "days_since_sterilization",
+    "days_since_plate",
+    "days_since_transplant",
+    "days_since_dome_removal",
+    "days_since_watering",
+    "liters_per_pot",
+    "is_good_day",
+    "cls_token",
+    "cls_token_pca",
+    "cls_token_umap",
+    "sterilized_date",
+    "plate_date",
+    "transplant_date",
+    "remove_domes_date",
+    "num_pots",
+    "num_pots_per_tray",
+    "bolted_prob",
+    "bolted_pred",
+]
+for i in range(6):
+    for trace in (0.5, 0.7, 0.9):
+        DROP_COLUMNS.append(f"action.{i}_trace_{trace}")
+for color in ("red", "white", "blue"):
+    for trace in (0.5, 0.7, 0.9):
+        DROP_COLUMNS.append(f"{color}_coef_trace_{trace}")
+
+
+def main() -> None:
+    default_dir = Path(f"/data/plant-rl/offline/{VERSION}")
+    parser = argparse.ArgumentParser(
+        description="Filter mixed parquet to E18 and write anffany-v1.parquet."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=default_dir / f"mixed-{VERSION}.parquet",
+        help="Input mixed parquet path",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=default_dir / "anffany-v1.1.parquet",
+        help="Output parquet path",
+    )
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        raise SystemExit(f"Input not found: {args.input}")
+
+    logger.info("Reading %s", args.input)
+    df = pl.read_parquet(args.input)
+
+    before = df.height
+    df = df.filter(pl.col("experiment") == EXPERIMENT)
+    logger.info("Kept %d / %d rows (E%d)", df.height, before, EXPERIMENT)
+
+    zones = df.select("zone").unique().sort("zone").to_series().to_list()
+    logger.info("Zones in output: %s", zones)
+
+    drop = [c for c in DROP_COLUMNS if c in df.columns]
+    df = df.drop(drop)
+    logger.info("Dropped %d columns (%d remaining)", len(drop), len(df.columns))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(args.output)
+    logger.info("Wrote %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fit_intensity_power.py
+++ b/scripts/fit_intensity_power.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Learn a scalar light-intensity → fixture power (W) function for E18.
+
+Power source: raw ~10 s resolution smart-plug logs integrated over the
+photoperiod via visualization/e18_power.daily_power_energy() — more accurate
+than the parquet's cumulative_energy diffs.
+
+Intensity source: mixed-e18-daily-v27.parquet, aggregated per (zone, day).
+
+Fits:
+  - Linear through origin:  P = k · a
+  - Affine:                  P = P₀ + P₁ · a
+
+Outputs:
+  results/intensity_power_fit.png
+  results/intensity_power_params.json
+
+Usage:
+  uv run python scripts/fit_intensity_power.py
+  uv run python scripts/fit_intensity_power.py --zones 1 3 4 11
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+from sklearn.linear_model import HuberRegressor
+from sklearn.metrics import r2_score
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+
+from config import VERSION
+from visualization.e18_power import PHOTOPERIOD_HOURS, daily_power_energy
+
+PARQUET = ROOT / f"/data/plant-rl/offline/{VERSION}/mixed-e18-daily-v27.parquet"
+ZONE_COLORS = {1: "#e74c3c", 3: "#3498db", 4: "#2ecc71", 11: "#9b59b6"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fit intensity → power model for E18.")
+    parser.add_argument("--parquet", default=str(PARQUET))
+    parser.add_argument("--zones", type=int, nargs="+", default=[1, 3, 4, 11])
+    parser.add_argument("--output", default="results/intensity_power_fit.png")
+    parser.add_argument("--save-params", default="results/intensity_power_params.json")
+    args = parser.parse_args()
+
+    # ---- power from raw logs (zone × date) ----
+    print("Integrating raw power logs...")
+    power_df = daily_power_energy(zones=args.zones)
+    if power_df.is_empty():
+        print("No raw power data found. Check E18_RAW_ROOT paths.")
+        return
+    print(f"  {power_df.height} zone-day power readings")
+
+    # ---- intensity from parquet (zone × date) ----
+    # The parquet time is America/Edmonton; the 9:00 AM local (Etc/GMT-2) row
+    # appears as 01:00 AM Edmonton, so the "local date" is time.dt.date() + 1 day
+    # in Edmonton. Recover local date by converting back to the zone's tz.
+    df = pl.read_parquet(
+        args.parquet,
+        columns=["zone", "day", "time", "intensity", "outlier"],
+    ).filter(pl.col("zone").is_in(args.zones))
+
+    # Local date: convert Edmonton time → Etc/GMT-2 and take date
+    intensity_by_zone_date = (
+        df.with_columns(
+            pl.col("time")
+            .dt.convert_time_zone("Etc/GMT-2")
+            .dt.date()
+            .alias("date")
+        )
+        .group_by(["zone", "date"])
+        .agg(pl.col("intensity").mean())
+        .sort("zone", "date")
+    )
+
+    # ---- join ----
+    joined = intensity_by_zone_date.join(
+        power_df.select(["zone", "date", "mean_power_W", "energy_Wh"]),
+        on=["zone", "date"],
+        how="inner",
+    ).filter(
+        pl.col("intensity").is_not_null() & pl.col("mean_power_W").is_not_null()
+    )
+
+    if joined.is_empty():
+        print("Join produced no rows. Check date alignment between parquet and raw logs.")
+        return
+
+    print(f"  {joined.height} joined (zone, date) pairs after inner join")
+
+    intensity = joined["intensity"].to_numpy()
+    power_W = joined["mean_power_W"].to_numpy()
+    zones_arr = joined["zone"].to_numpy()
+
+    # ---- Model 1: linear through origin  P = k · a ----
+    k_ols = float((power_W @ intensity) / (intensity @ intensity))
+    pred_linear = k_ols * intensity
+    r2_linear = r2_score(power_W, pred_linear)
+
+    # Robust variant (Huber)
+    hub = HuberRegressor(fit_intercept=False)
+    hub.fit(intensity.reshape(-1, 1), power_W)
+    k_huber = float(hub.coef_[0])
+    pred_huber = k_huber * intensity
+    r2_huber = r2_score(power_W, pred_huber)
+
+    # ---- Model 2: affine  P = P₀ + P₁ · a ----
+    X2 = np.column_stack([np.ones_like(intensity), intensity])
+    coef_aff, *_ = np.linalg.lstsq(X2, power_W, rcond=None)
+    P0_aff, P1_aff = coef_aff
+    pred_affine = P0_aff + P1_aff * intensity
+    r2_affine = r2_score(power_W, pred_affine)
+
+    # Robust affine
+    hub2 = HuberRegressor(fit_intercept=True)
+    hub2.fit(intensity.reshape(-1, 1), power_W)
+    P0_hub2, P1_hub2 = float(hub2.intercept_), float(hub2.coef_[0])
+    pred_hub2 = P0_hub2 + P1_hub2 * intensity
+    r2_hub2 = r2_score(power_W, pred_hub2)
+
+    print(f"\nLinear  P = k · a  (OLS):    k = {k_ols:.3f} W   R² = {r2_linear:.4f}")
+    print(f"Linear  P = k · a  (Huber):  k = {k_huber:.3f} W   R² = {r2_huber:.4f}")
+    print(f"Affine  P = P₀ + P₁·a  (OLS):   P₀={P0_aff:.3f} W  P₁={P1_aff:.3f} W  R²={r2_affine:.4f}")
+    print(f"Affine  P = P₀ + P₁·a  (Huber): P₀={P0_hub2:.3f} W  P₁={P1_hub2:.3f} W  R²={r2_hub2:.4f}")
+
+    # ---- Per-zone linear slope (through origin) ----
+    per_zone = {}
+    print("\nPer-zone linear (P = k_z · a):")
+    for zone in sorted(args.zones):
+        mask = zones_arr == zone
+        a_z, p_z = intensity[mask], power_W[mask]
+        if len(a_z) < 2:
+            continue
+        k_z = float((p_z @ a_z) / (a_z @ a_z))
+        r2_z = r2_score(p_z, k_z * a_z)
+        per_zone[zone] = {"k_W": k_z, "r2": r2_z, "n": int(len(a_z))}
+        print(f"  Z{zone}: k = {k_z:.3f} W  R² = {r2_z:.4f}  (n={len(a_z)})")
+
+    # ---- Plot ----
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+
+    for zone in args.zones:
+        mask = zones_arr == zone
+        ax1.scatter(
+            intensity[mask], power_W[mask],
+            color=ZONE_COLORS.get(zone, "gray"),
+            alpha=0.6, s=40, label=f"Z{zone}", zorder=3,
+        )
+
+    x_plot = np.linspace(intensity.min() * 0.9, intensity.max() * 1.05, 300)
+    ax1.plot(x_plot, k_ols * x_plot, "k-", lw=2,
+             label=f"Linear OLS  k={k_ols:.1f} W (R²={r2_linear:.3f})")
+    ax1.plot(x_plot, P0_aff + P1_aff * x_plot, color="steelblue", lw=1.5, linestyle="-.",
+             label=f"Affine OLS P₀={P0_aff:.1f}+{P1_aff:.1f}·a (R²={r2_affine:.3f})")
+    for zone, info in per_zone.items():
+        mask = zones_arr == zone
+        a_range = np.linspace(intensity[mask].min(), intensity[mask].max(), 100)
+        ax1.plot(a_range, info["k_W"] * a_range,
+                 color=ZONE_COLORS.get(zone, "gray"), lw=1, linestyle=":",
+                 label=f"Z{zone} k={info['k_W']:.1f} W")
+    ax1.set_xlabel("Intensity (a)")
+    ax1.set_ylabel("Mean photoperiod power (W)")
+    ax1.set_title("Intensity → Power")
+    ax1.legend(fontsize=7.5)
+    ax1.grid(True, alpha=0.25)
+    ax1.spines[["top", "right"]].set_visible(False)
+
+    # Right: residuals from global linear model, coloured by zone
+    resid = power_W - k_ols * intensity
+    for zone in args.zones:
+        mask = zones_arr == zone
+        ax2.scatter(
+            intensity[mask], resid[mask],
+            color=ZONE_COLORS.get(zone, "gray"),
+            alpha=0.6, s=40, label=f"Z{zone}", zorder=3,
+        )
+    ax2.axhline(0, color="k", lw=0.8, linestyle="--")
+    ax2.set_xlabel("Intensity (a)")
+    ax2.set_ylabel("Residual (W)")
+    ax2.set_title(f"Residuals — Global linear (k={k_ols:.2f} W)")
+    ax2.legend(fontsize=8)
+    ax2.grid(True, alpha=0.25)
+    ax2.spines[["top", "right"]].set_visible(False)
+
+    fig.suptitle(
+        f"E18 intensity → power fit  ({PHOTOPERIOD_HOURS:.0f} h photoperiod, n={len(intensity)} zone-days)",
+        fontsize=12, fontweight="bold",
+    )
+    fig.tight_layout()
+
+    out_plot = ROOT / args.output
+    out_plot.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_plot, dpi=150, bbox_inches="tight")
+    print(f"\nPlot saved → {out_plot}")
+
+    # ---- Save params ----
+    params = {
+        "photoperiod_h": PHOTOPERIOD_HOURS,
+        "n_zone_days": int(len(intensity)),
+        "linear_ols": {"k_W": k_ols, "r2": r2_linear},
+        "linear_huber": {"k_W": k_huber, "r2": r2_huber},
+        "affine_ols": {"P0_W": P0_aff, "P1_W": P1_aff, "r2": r2_affine},
+        "affine_huber": {"P0_W": P0_hub2, "P1_W": P1_hub2, "r2": r2_hub2},
+        "per_zone_linear": {f"zone_{z}": v for z, v in per_zone.items()},
+    }
+    out_params = ROOT / args.save_params
+    out_params.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_params, "w") as f:
+        json.dump(params, f, indent=2)
+    print(f"Params saved → {out_params}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/create_frame_strip.py
+++ b/visualization/create_frame_strip.py
@@ -279,7 +279,7 @@ def main():
     df = pl.read_parquet(args.parquet)
 
     # Build agent order and zone map from data
-    pdf = load_episode_metrics(Path(args.parquet), args.experiment)
+    pdf = load_episode_metrics(Path(args.parquet), args.experiment, args.max_day + 1)
     agent_order, zone_map, _, _, _ = build_layout(pdf)
     logging.info(f"Agents: {agent_order}, Zone map: {zone_map}")
 

--- a/visualization/e18_power.py
+++ b/visualization/e18_power.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for E18 power / energy analysis.
+
+WHY THIS EXISTS
+---------------
+The offline parquet (mixed-vXX) stores `power` only at the 4-hourly subsample
+points (09:00 / 13:00 / 17:00 local). Summing that column is *not* a correct
+energy integral for two reasons:
+
+  1. The 09:00 sample lands during the lights-on ramp-up (the smart plug reads
+     ~20 W mid-transition instead of the steady ~47 W), so it is a low outlier
+     for every zone.
+  2. Three points per day cannot capture within-day ramp shapes
+     (Parabolic / LateRamp etc.), so the integral is badly biased.
+
+These helpers instead integrate the *raw* (~10 s resolution) power logs over the
+full photoperiod, which reproduces the designed energy fractions. Energy is
+estimated as (mean photoperiod power) x (photoperiod hours), which is robust to
+the irregular / duplicated raw timestamps.
+"""
+
+import json
+from datetime import time
+from pathlib import Path
+
+import polars as pl
+
+# Photoperiod for E18: lights on 09:00-21:00 local (config timezone).
+PHOTOPERIOD_START = time(9, 0)
+PHOTOPERIOD_END = time(21, 0)
+PHOTOPERIOD_HOURS = 12.0
+DEFAULT_TZ = "Etc/GMT-2"
+
+E18_RAW_ROOT = Path("/data/plant-rl/online/E18/P1")
+
+# zone -> raw run directory (authoritative: generate.sh P1 block).
+E18_RAW_DIRS = {
+    1: "SequencePowerLawRamp1/alliance-zone01",
+    2: "SequenceParabolic2/alliance-zone02",
+    3: "ConstantLow3/alliance-zone03",
+    4: "SequenceSeventyPercentRamp4/alliance-zone04",
+    5: "SequenceLateRamp5/alliance-zone05",
+    6: "Schedule6/alliance-zone06",
+    7: "Schedule7/alliance-zone07",
+    8: "Schedule8/alliance-zone08",
+    9: "Schedule9/alliance-zone09",
+    10: "Schedule10/alliance-zone10",
+    11: "Constant11/alliance-zone11",
+}
+
+
+def _zone_timezone(zone_dir: Path) -> str:
+    config_path = zone_dir / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                return json.load(f).get("timezone", DEFAULT_TZ)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return DEFAULT_TZ
+
+
+def daily_power_energy(
+    zones=None,
+    raw_root: Path = E18_RAW_ROOT,
+    start_date=None,
+) -> pl.DataFrame:
+    """Integrate raw power over the photoperiod for each E18 zone and day.
+
+    Returns a long DataFrame with columns:
+        zone, date, day, mean_power_W, energy_Wh
+    where ``mean_power_W`` is the mean power over the photoperiod and
+    ``energy_Wh = mean_power_W * PHOTOPERIOD_HOURS``. ``day`` is the integer day
+    index relative to the earliest photoperiod date observed (across all zones),
+    or relative to ``start_date`` if given.
+    """
+    if zones is None:
+        zones = list(E18_RAW_DIRS)
+
+    frames = []
+    for zone in zones:
+        rel = E18_RAW_DIRS.get(zone)
+        if rel is None:
+            continue
+        zone_dir = raw_root / rel
+        files = sorted(zone_dir.glob("raw_*.csv"))
+        if not files:
+            continue
+        tz = _zone_timezone(zone_dir)
+        parts = []
+        for f in files:
+            try:
+                parts.append(
+                    pl.read_csv(
+                        f,
+                        try_parse_dates=True,
+                        infer_schema_length=10000,
+                        columns=["time", "power"],
+                    )
+                )
+            except Exception:
+                continue
+        if not parts:
+            continue
+        df = (
+            pl.concat(parts, how="diagonal_relaxed")
+            .unique(subset=["time"])
+            .drop_nulls("power")
+            .with_columns(pl.col("time").dt.convert_time_zone(tz))
+        )
+        df = df.filter(
+            (pl.col("time").dt.time() >= PHOTOPERIOD_START)
+            & (pl.col("time").dt.time() < PHOTOPERIOD_END)
+        )
+        if df.is_empty():
+            continue
+        per_day = (
+            df.with_columns(pl.col("time").dt.date().alias("date"))
+            .group_by("date")
+            .agg(pl.col("power").mean().alias("mean_power_W"))
+            .with_columns(
+                pl.lit(zone).alias("zone"),
+                (pl.col("mean_power_W") * PHOTOPERIOD_HOURS).alias("energy_Wh"),
+            )
+        )
+        frames.append(per_day)
+
+    if not frames:
+        return pl.DataFrame(
+            schema={
+                "zone": pl.Int64,
+                "date": pl.Date,
+                "day": pl.Int64,
+                "mean_power_W": pl.Float64,
+                "energy_Wh": pl.Float64,
+            }
+        )
+
+    out = pl.concat(frames, how="diagonal_relaxed")
+    anchor = start_date if start_date is not None else out["date"].min()
+    out = out.with_columns(
+        ((pl.col("date") - pl.lit(anchor)).dt.total_days()).alias("day")
+    )
+    return out.sort("zone", "date").select(
+        "zone", "date", "day", "mean_power_W", "energy_Wh"
+    )

--- a/visualization/plot_e18_biomass_validation.py
+++ b/visualization/plot_e18_biomass_validation.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Compare E18 zone averages: biomass, final vision area, and return."""
+
+import argparse
+import re
+import sys
+from datetime import time
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+import seaborn as sns
+from scipy import stats
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config import E18_POLICY_MAP, VERSION, tzinfo
+
+BIOMASS_CSV = "Plant RL Schedule 2026 - Biomass (Fresh Weight) 2026.06.15.csv"
+FINAL_TIME = time(1, 0, tzinfo=tzinfo)
+POLICY_ORDER = [E18_POLICY_MAP[z] for z in [11, 3, 1, 2, 4, 5, 6, 7, 8, 9, 10]]
+
+
+def load_biomass(csv_path: Path) -> pd.DataFrame:
+    raw = pd.read_csv(csv_path, header=None)
+    headers = raw.iloc[1, 1:13].tolist()
+    avg_row = raw.iloc[-1, 1:13]
+    rows = []
+    for j, h in enumerate(headers):
+        m = re.match(r"zone (\d+)", str(h).strip().lower())
+        if m:
+            rows.append({"zone": int(m.group(1)), "biomass_g": float(avg_row.iloc[j])})
+    return pd.DataFrame(rows).groupby("zone")["biomass_g"].mean().reset_index()
+
+
+def load_metrics(parquet_path: Path, max_day: int) -> pd.DataFrame:
+    df = pl.read_parquet(parquet_path).filter(pl.col("experiment") == 18)
+
+    final = (
+        df.filter((pl.col("day") == 14) & (pl.col("time").dt.time() == FINAL_TIME))
+        .group_by("zone")
+        .agg(pl.col("clean_area").mean().alias("final_area"))
+    )
+    returns = (
+        df.filter(pl.col("day") <= max_day)
+        .group_by(["zone", "plant_id"])
+        .agg(pl.col("reward").sum().alias("return"))
+        .group_by("zone")
+        .agg(pl.col("return").mean().alias("return_mean"))
+    )
+    return returns.join(final, on="zone").sort("zone").to_pandas()
+
+
+def normalize(series: pd.Series) -> pd.Series:
+    lo, hi = series.min(), series.max()
+    if hi == lo:
+        return pd.Series(0.5, index=series.index)
+    return (series - lo) / (hi - lo)
+
+
+def corr_label(x: np.ndarray, y: np.ndarray) -> str:
+    r, p = stats.pearsonr(x, y)
+    rho, _ = stats.spearmanr(x, y)
+    return f"Pearson r = {r:.2f} (p = {p:.2f})\nSpearman ρ = {rho:.2f}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot E18 biomass vs final area vs return by zone."
+    )
+    parser.add_argument(
+        "--parquet",
+        "-p",
+        default=f"/data/plant-rl/offline/{VERSION}/mixed-{VERSION}.parquet",
+    )
+    parser.add_argument(
+        "--biomass-csv",
+        default=BIOMASS_CSV,
+        help="Biomass harvest CSV with AVG row",
+    )
+    parser.add_argument(
+        "--out",
+        "-o",
+        default="results/e18_biomass_validation.png",
+    )
+    parser.add_argument("--max-day", type=int, default=13)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent.parent
+    biomass = load_biomass(root / args.biomass_csv)
+    metrics = load_metrics(args.parquet, args.max_day)
+    df = metrics.merge(biomass, on="zone")
+    df["policy"] = df["zone"].map(E18_POLICY_MAP)
+    df["label"] = df.apply(lambda r: f"Z{int(r.zone)}\n{r.policy[:18]}", axis=1)
+    df = df.set_index("policy").loc[POLICY_ORDER].reset_index()
+    df["norm_return"] = normalize(df["return_mean"])
+    df["norm_area"] = normalize(df["final_area"])
+    df["norm_biomass"] = normalize(df["biomass_g"])
+
+    sns.set_theme(style="whitegrid", context="talk")
+    fig, axes = plt.subplots(1, 3, figsize=(18, 6), constrained_layout=True)
+
+    # 1. Normalized grouped bars
+    ax = axes[0]
+    x = np.arange(len(df))
+    w = 0.25
+    ax.bar(x - w, df["norm_return"], width=w, label="Return", color="#3498db")
+    ax.bar(x, df["norm_area"], width=w, label="Final area", color="#2ecc71")
+    ax.bar(x + w, df["norm_biomass"], width=w, label="Biomass", color="#e67e22")
+    ax.set_xticks(x)
+    ax.set_xticklabels(df["label"], rotation=45, ha="right", fontsize=9)
+    ax.set_ylabel("Normalized (0 = min, 1 = max)")
+    ax.set_title("Zone rankings (normalized)", fontweight="bold")
+    ax.legend(loc="upper right", fontsize=10)
+
+    # 2. Final area vs biomass
+    ax = axes[1]
+    sns.regplot(
+        data=df,
+        x="final_area",
+        y="biomass_g",
+        ax=ax,
+        scatter_kws={"s": 100, "color": "#2ecc71", "edgecolors": "k", "linewidths": 0.5},
+        line_kws={"color": "#27ae60"},
+        ci=95,
+    )
+    for _, row in df.iterrows():
+        ax.annotate(
+            f"Z{int(row.zone)}",
+            (row.final_area, row.biomass_g),
+            textcoords="offset points",
+            xytext=(4, 4),
+            fontsize=9,
+        )
+    ax.set_xlabel("Final clean_area (day 14 01:00)")
+    ax.set_ylabel("Biomass (g)")
+    ax.set_title("Final area vs biomass", fontweight="bold")
+    ax.text(
+        0.05, 0.95, corr_label(df["final_area"].values, df["biomass_g"].values),
+        transform=ax.transAxes, va="top", fontsize=10,
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+    )
+
+    # 3. Return vs biomass
+    ax = axes[2]
+    sns.regplot(
+        data=df,
+        x="return_mean",
+        y="biomass_g",
+        ax=ax,
+        scatter_kws={"s": 100, "color": "#3498db", "edgecolors": "k", "linewidths": 0.5},
+        line_kws={"color": "#2980b9"},
+        ci=95,
+    )
+    for _, row in df.iterrows():
+        ax.annotate(
+            f"Z{int(row.zone)}",
+            (row.return_mean, row.biomass_g),
+            textcoords="offset points",
+            xytext=(4, 4),
+            fontsize=9,
+        )
+    ax.set_xlabel(f"Return (reward sum, day ≤ {args.max_day})")
+    ax.set_ylabel("Biomass (g)")
+    ax.set_title("Return vs biomass", fontweight="bold")
+    ax.text(
+        0.05, 0.95, corr_label(df["return_mean"].values, df["biomass_g"].values),
+        transform=ax.transAxes, va="top", fontsize=10,
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+    )
+
+    fig.suptitle(
+        "E18: Biomass vs vision final area vs return",
+        fontsize=14,
+        fontweight="bold",
+        y=1.02,
+    )
+
+    out = root / args.out
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    print(f"Saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/plot_e18_daily_dataset.py
+++ b/visualization/plot_e18_daily_dataset.py
@@ -1,0 +1,115 @@
+"""
+Verification dashboard for the E18 daily dataset (mixed-e18-daily-v27.parquet).
+
+Shows per-zone trajectories (mean ± 95% CI across plants) for:
+  - Intensity (action)
+  - Clean area
+  - Daily reward
+  - Daily energy (Wh)
+"""
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config import E18_POLICY_MAP, VERSION
+
+PARQUET = Path(f"/data/plant-rl/offline/{VERSION}/mixed-e18-daily-v27.parquet")
+OUTPUT = Path("results/e18_daily_dataset_verification.png")
+
+ZONE_ORDER = [1, 3, 4, 11]
+ZONE_COLORS = {1: "#e74c3c", 3: "#3498db", 4: "#2ecc71", 11: "#9b59b6"}
+
+
+def bootstrap_ci(vals: np.ndarray, n_boot: int = 2000, ci: float = 0.95, seed: int = 0):
+    vals = vals[np.isfinite(vals)]
+    if len(vals) == 0:
+        return np.nan, np.nan, np.nan
+    if len(vals) == 1:
+        v = float(vals[0])
+        return v, v, v
+    rng = np.random.default_rng(seed)
+    boots = rng.choice(vals, size=(n_boot, len(vals)), replace=True).mean(axis=1)
+    alpha = (1 - ci) / 2
+    return float(vals.mean()), float(np.quantile(boots, alpha)), float(np.quantile(boots, 1 - alpha))
+
+
+def summarize(pdf, metric: str):
+    rows = []
+    for (zone, day), g in pdf.groupby(["zone", "day"]):
+        vals = g[metric].dropna().to_numpy(dtype=float)
+        mean, lo, hi = bootstrap_ci(vals, seed=int(zone * 100 + day))
+        rows.append({"zone": int(zone), "day": int(day), "mean": mean, "lo": lo, "hi": hi})
+    import pandas as pd
+    return pd.DataFrame(rows).sort_values(["zone", "day"])
+
+
+def main():
+    import pandas as pd
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parquet", default=str(PARQUET))
+    parser.add_argument("--output", default=str(OUTPUT))
+    args = parser.parse_args()
+
+    path = Path(args.parquet)
+    print(f"Loading {path} ...")
+    df = pl.read_parquet(path, columns=[
+        "zone", "day", "plant_id", "intensity", "clean_area",
+        "area_reward", "reward", "energy", "agent",
+    ])
+    pdf = df.to_pandas()
+
+    metrics = [
+        ("intensity", "Intensity (a = Σchannel / 100)", False),
+        ("clean_area", "Clean area (cm²)", False),
+        ("area_reward", "Area reward (Δ log area)", True),
+        ("energy", "Energy (Wh / day)", False),
+        ("reward", "RL reward (area − β·ΔlogE, β=1)", True),
+    ]
+
+    fig, axes = plt.subplots(len(metrics), 1, figsize=(10, 4 * len(metrics)), sharex=True)
+    plt.rcParams.update({"font.family": "sans-serif"})
+
+    for ax, (metric, ylabel, zero_line) in zip(axes, metrics):
+        summ = summarize(pdf, metric)
+        for zone in ZONE_ORDER:
+            g = summ[summ["zone"] == zone]
+            if g.empty:
+                continue
+            policy = E18_POLICY_MAP.get(zone, f"Z{zone}")
+            label = f"Z{zone} {policy}"
+            color = ZONE_COLORS[zone]
+            x = g["day"].to_numpy()
+            y = g["mean"].to_numpy()
+            lo = g["lo"].to_numpy()
+            hi = g["hi"].to_numpy()
+            ax.plot(x, y, color=color, linewidth=2, label=label)
+            ax.fill_between(x, lo, hi, color=color, alpha=0.18)
+        if zero_line:
+            ax.axhline(0, color="k", linewidth=0.7, linestyle="--", alpha=0.4)
+        ax.set_ylabel(ylabel)
+        ax.grid(True, alpha=0.25)
+        ax.spines[["top", "right"]].set_visible(False)
+        ax.legend(fontsize=9, ncol=2, framealpha=0.85)
+
+    axes[-1].set_xlabel("Day")
+    fig.suptitle(
+        "E18 daily dataset — Zones 1, 3, 4, 11\n(mean ± 95% bootstrap CI across plants)",
+        fontsize=13, fontweight="bold", y=1.01,
+    )
+    fig.tight_layout()
+
+    out = Path(__file__).resolve().parent.parent / args.output
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    print(f"Saved → {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/plot_e18_power_energy.py
+++ b/visualization/plot_e18_power_energy.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Plot E18 power use and cumulative energy over time, one line per agent/policy.
+
+Data are at 4-hourly subsample timesteps (~3 per photoperiod day). Uses
+per-interval ``energy`` (Wh) and ``cumulative_energy`` from the offline
+parquet.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+import seaborn as sns
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config import E18_POLICY_MAP, VERSION
+
+# Slide-style palette (slides/scripts/make_slide_figures.py / make_film_strip.py).
+BG = "#FAFAF7"
+MUTED = "#9A9A93"
+# E18 photoperiod 09:00–21:00; wall_time 0 = 09:30 on day 0.
+PHOTO_START = -0.5 / 24
+PHOTO_END = 11.5 / 24
+
+
+def add_night_shading(ax, max_day: int) -> None:
+    """Gray bands for dark hours; photoperiod stays on the off-white background."""
+    for d in range(max_day + 2):
+        ax.axvspan(
+            d + PHOTO_END,
+            d + 1 + PHOTO_START,
+            color=MUTED,
+            alpha=0.12,
+            linewidth=0,
+            zorder=0,
+        )
+    ax.set_facecolor(BG)
+    ax.grid(False)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot E18 power use and cumulative energy over time by agent."
+    )
+    parser.add_argument(
+        "--parquet",
+        "-p",
+        default=f"/data/plant-rl/offline/{VERSION}/mixed-{VERSION}.parquet",
+        help="Path to parquet file",
+    )
+    parser.add_argument(
+        "--out",
+        "-o",
+        default="results/e18_power_energy_over_time.png",
+        help="Output file path for the plot",
+    )
+    parser.add_argument(
+        "--max-day", type=int, default=13, help="Only plot days <= this index (day 13 is terminal)"
+    )
+    args = parser.parse_args()
+
+    print(f"Reading parquet: {args.parquet}")
+    df = pl.read_parquet(args.parquet).filter(pl.col("experiment") == 18)
+    for col in ("energy", "cumulative_energy"):
+        if col not in df.columns:
+            print(f"No `{col}` column found -- regenerate the dataset (generate.sh).")
+            sys.exit(1)
+
+    # One row per (zone, time) at 4-hourly resolution.
+    steps = (
+        df.select("zone", "time", "day", "wall_time", "energy", "cumulative_energy")
+        .unique(subset=["zone", "time"])
+        .filter(pl.col("day") <= args.max_day)
+        .sort("zone", "time")
+        .with_columns(
+            pl.col("zone").replace_strict(E18_POLICY_MAP, default="Unknown").alias("policy"),
+        )
+        .filter(pl.col("policy") != "Unknown")
+        .filter(pl.col("energy").is_not_null())
+        .sort("zone", "wall_time")
+    )
+
+    pdf = steps.to_pandas()
+    if pdf.empty:
+        print("No E18 energy data found.")
+        sys.exit(1)
+
+    # Break lines at day boundaries (one photoperiod segment per day).
+    pdf = pdf.sort_values(["zone", "wall_time"])
+    pdf["segment"] = pdf.groupby("zone")["day"].transform(
+        lambda d: d.ne(d.shift()).cumsum().fillna(0).astype(int)
+    )
+    pdf["line_id"] = pdf["zone"].astype(str) + "_" + pdf["segment"].astype(str)
+
+    policy_order = [
+        E18_POLICY_MAP[z]
+        for z in [11, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        if E18_POLICY_MAP[z] in set(pdf["policy"])
+    ]
+    palette = dict(zip(policy_order, sns.color_palette("husl", len(policy_order))))
+
+    sns.set_theme(style="white")
+    fig, axes = plt.subplots(1, 2, figsize=(16, 6), facecolor=BG)
+
+    for ax in axes:
+        add_night_shading(ax, args.max_day)
+
+    sns.lineplot(
+        data=pdf, x="wall_time", y="energy", hue="policy", units="line_id",
+        hue_order=policy_order, palette=palette, estimator=None,
+        ax=axes[0], linewidth=1.5, legend=False,
+    )
+    axes[0].set_title("Interval Energy by Agent (4-hourly)", fontsize=13, fontweight="bold")
+    axes[0].set_xlabel("Wall time (days)", fontsize=11)
+    axes[0].set_ylabel("Energy over interval (Wh)", fontsize=11)
+
+    sns.lineplot(
+        data=pdf, x="wall_time", y="cumulative_energy", hue="policy", units="line_id",
+        hue_order=policy_order, palette=palette, estimator=None,
+        ax=axes[1], linewidth=1.5, legend=False,
+    )
+    axes[1].set_title("Cumulative Energy by Agent (4-hourly)", fontsize=13, fontweight="bold")
+    axes[1].set_xlabel("Wall time (days)", fontsize=11)
+    axes[1].set_ylabel("Cumulative energy (Wh)", fontsize=11)
+
+    for ax in axes:
+        sns.despine(ax=ax)
+
+    handles = [
+        plt.Line2D([0], [0], color=palette[p], linewidth=1.5, label=p)
+        for p in policy_order
+    ]
+    fig.legend(
+        handles=handles,
+        title="Policy / Agent",
+        loc="center left",
+        bbox_to_anchor=(1.01, 0.5),
+        frameon=False,
+        fontsize=8,
+    )
+
+    plt.tight_layout()
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200, bbox_inches="tight", facecolor=BG)
+    plt.close()
+    print(f"Saved power/energy over time plot to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/plot_e18_return_energy.py
+++ b/visualization/plot_e18_return_energy.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Plot return and energy usage for Experiment 18, grouped by agent/policy.
+
+Uses the pre-computed reward columns from mixed-e18-daily-v27.parquet:
+  area_reward               — daily Δ log_clean_area (growth)
+  energy_reward_schema_a_β  — β · (log energy_t − log e_const)
+  energy_reward_schema_b    — per-step gated energy cost
+  reward                    — area_reward − energy_reward_schema_a_1
+
+Return for each schema = per-plant sum of (area_reward − schema_energy_reward).
+Energy per zone = median daily energy × number of experiment days.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+import seaborn as sns
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config import E18_POLICY_MAP, VERSION
+
+SCHEMA_A_BETAS = [0.5, 1.0, 2.0, 4.0, 8.0]
+
+_TOL_RAINBOW_11 = [
+    "#882E72", "#1965B0", "#7BAFDE", "#4EB265", "#CAE0AB",
+    "#F7CB45", "#EE8026", "#E65518", "#DC050C", "#72190E", "#42150A",
+]
+PARETO_COLOR = "#2C4875"
+
+
+def _build_palette(n: int) -> list[str]:
+    try:
+        import tol_colors as tc
+        import matplotlib.colors as mcolors
+        return [mcolors.to_hex(c) for c in tc.rainbow_discrete(n).colors]
+    except ImportError:
+        return [_TOL_RAINBOW_11[i % len(_TOL_RAINBOW_11)] for i in range(n)]
+
+
+def percentile_bounds(x: np.ndarray, lo_pct: float = 15, hi_pct: float = 100):
+    lo, hi = np.percentile(x, [lo_pct, hi_pct])
+    return float(lo), float(hi)
+
+
+def inner_percentile_mean(x: np.ndarray, lo_pct: float = 15, hi_pct: float = 100) -> float:
+    x = np.asarray(x, dtype=float)
+    if len(x) == 0:
+        return 0.0
+    if len(x) == 1:
+        return float(x[0])
+    lo, hi = np.percentile(x, [lo_pct, hi_pct])
+    trimmed = x[(x >= lo) & (x <= hi)]
+    return float((trimmed if len(trimmed) else x).mean())
+
+
+def inner_percentile_mean_ci(
+    x: np.ndarray, lo_pct: float = 15, hi_pct: float = 100,
+    ci: float = 0.95, n_boot: int = 2000, seed: int = 0,
+) -> tuple[float, float, float]:
+    x = np.asarray(x, dtype=float)
+    p_lo, p_hi = np.percentile(x, [lo_pct, hi_pct])
+    cleaned = x[(x >= p_lo) & (x <= p_hi)]
+    if len(cleaned) == 0:
+        cleaned = x
+    mean = float(cleaned.mean())
+    if len(cleaned) <= 1:
+        return mean, mean, mean
+    rng = np.random.default_rng(seed)
+    boots = rng.choice(cleaned, size=(n_boot, len(cleaned)), replace=True).mean(axis=1)
+    alpha = (1 - ci) / 2
+    lo, hi = np.percentile(boots, [100 * alpha, 100 * (1 - alpha)])
+    return mean, float(lo), float(hi)
+
+
+TRIM_LO_PCT = 10
+TRIM_HI_PCT = 99
+
+
+def policy_summary(rdf: pd.DataFrame, return_col: str, edf: dict, policy_order: list) -> pd.DataFrame:
+    rows = []
+    for policy in policy_order:
+        p_df = rdf[rdf["policy"] == policy]
+        if p_df.empty:
+            continue
+        mean_ret, ret_lo, ret_hi = inner_percentile_mean_ci(
+            p_df[return_col].to_numpy(), TRIM_LO_PCT, TRIM_HI_PCT,
+        )
+        rows.append({
+            "policy": policy,
+            "return_mean": mean_ret,
+            "return_ci_lo": ret_lo,
+            "return_ci_hi": ret_hi,
+            "energy": edf[policy],
+        })
+    return pd.DataFrame(rows)
+
+
+def plot_tradeoff_panel(
+    ax, s_df: pd.DataFrame, color_map: dict, *,
+    title: str | None = None,
+    const_return: float | None = None,
+    const_label: str = "Constant",
+):
+    s_df_sorted = s_df.sort_values("energy")
+    pareto, max_return_seen = [], -1e9
+    for _, row in s_df_sorted.iterrows():
+        if row["return_mean"] > max_return_seen:
+            pareto.append(row)
+            max_return_seen = row["return_mean"]
+    pareto_df = pd.DataFrame(pareto)
+
+    if not pareto_df.empty:
+        ax.plot(
+            pareto_df["energy"], pareto_df["return_mean"],
+            color=PARETO_COLOR, linestyle="--", linewidth=2.0, alpha=0.9,
+            label="Pareto Frontier", zorder=2,
+        )
+    for _, row in s_df_sorted.iterrows():
+        ax.errorbar(
+            row["energy"], row["return_mean"],
+            yerr=[[row["return_mean"] - row["return_ci_lo"]],
+                  [row["return_ci_hi"] - row["return_mean"]]],
+            fmt="o", color=color_map[row["policy"]], ecolor="#888888",
+            elinewidth=1.4, capsize=3.5, markersize=9, zorder=3,
+        )
+    if const_return is not None:
+        ax.axhline(const_return, color="#888888", linestyle="--", linewidth=1.4,
+                   zorder=0, label=const_label)
+    ax.set_xlabel("Energy (Wh)", fontsize=11)
+    ax.set_ylabel("Return", fontsize=11, rotation=0, ha="right", va="center")
+    if title:
+        ax.set_title(title, fontsize=11, fontweight="bold")
+    ax.legend(fontsize=8, framealpha=0.0, edgecolor="none")
+    sns.despine(ax=ax, top=True, right=True)
+
+
+def plot_schema_returns_figure(
+    rdf: pd.DataFrame,
+    edf: dict[str, float],
+    policy_order: list[str],
+    color_map: dict[str, str],
+    const_policy: str,
+    out_path: Path,
+):
+    """Schema A (all betas) + Schema B trade-off panels using pre-computed returns."""
+    const_return = inner_percentile_mean(
+        rdf.loc[rdf["policy"] == const_policy, "area_return"].to_numpy(),
+        TRIM_LO_PCT, TRIM_HI_PCT,
+    )
+
+    n_betas = len(SCHEMA_A_BETAS)
+    sns.set_theme(style="white")
+    fig = plt.figure(figsize=(3.5 * n_betas, 7), constrained_layout=True)
+    gs = fig.add_gridspec(2, n_betas, hspace=0.35, wspace=0.3)
+
+    # Top row: Schema A, one panel per beta
+    for i, beta in enumerate(SCHEMA_A_BETAS):
+        col = f"return_schema_a_{beta:g}"
+        s_df = policy_summary(rdf, col, edf, policy_order)
+        ax = fig.add_subplot(gs[0, i])
+        plot_tradeoff_panel(
+            ax, s_df, color_map,
+            title=f"Schema A: β={beta:g}",
+            const_return=inner_percentile_mean(
+                rdf.loc[rdf["policy"] == const_policy, col].to_numpy(),
+                TRIM_LO_PCT, TRIM_HI_PCT,
+            ),
+        )
+
+    # Bottom row: Schema B (centred)
+    s_df_b = policy_summary(rdf, "return_schema_b", edf, policy_order)
+    const_return_b = inner_percentile_mean(
+        rdf.loc[rdf["policy"] == const_policy, "return_schema_b"].to_numpy(),
+        TRIM_LO_PCT, TRIM_HI_PCT,
+    )
+    mid = n_betas // 2
+    span = 2 if n_betas >= 4 else 1
+    ax_b = fig.add_subplot(gs[1, mid - span // 2: mid - span // 2 + span + (1 if n_betas % 2 else 0)])
+    plot_tradeoff_panel(
+        ax_b, s_df_b, color_map,
+        title="Schema B (step-gated energy reward)",
+        const_return=const_return_b,
+        const_label="Constant",
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+    print(f"Saved schema return plot to {out_path}")
+
+
+def policy_label(name: str) -> str:
+    return name.removeprefix("Sequence")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot Return and Energy Usage for Experiment 18 grouped by agent."
+    )
+    parser.add_argument(
+        "--parquet", "-p",
+        default=f"/data/plant-rl/offline/{VERSION}/mixed-e18-daily-v27.parquet",
+    )
+    parser.add_argument("--out", "-o", default="results/e18_return_energy.png")
+    parser.add_argument(
+        "--out-schemas", default="results/e18_return_energy_schemas.png",
+        help="Second figure: Schema A (all betas) and Schema B returns.",
+    )
+    parser.add_argument("--max-day", type=int, default=13)
+    args = parser.parse_args()
+
+    print(f"Reading parquet: {args.parquet}")
+    df = pl.read_parquet(args.parquet)
+
+    # Check for the pre-computed reward columns
+    required = ["area_reward", "reward", "energy_reward_schema_b"] + [
+        f"energy_reward_schema_a_{b:g}" for b in SCHEMA_A_BETAS
+    ]
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        print(f"Missing columns: {missing}")
+        print("Re-generate the parquet with join_zones.py --subsample daily.")
+        sys.exit(1)
+
+    df_e18 = df.filter(pl.col("experiment") == 18).with_columns(
+        pl.col("zone").replace_strict(E18_POLICY_MAP, default="Unknown").alias("policy")
+    ).filter((pl.col("policy") != "Unknown") & (pl.col("day") <= args.max_day))
+
+    if df_e18.is_empty():
+        print("No E18 data found.")
+        sys.exit(1)
+
+    # ── Per-plant returns from pre-computed step rewards ──────────────────────
+    agg_exprs = [
+        pl.col("area_reward").sum().alias("area_return"),
+        pl.col("reward").sum().alias("reward_return"),
+    ]
+    for beta in SCHEMA_A_BETAS:
+        col = f"energy_reward_schema_a_{beta:g}"
+        agg_exprs.append(
+            (pl.col("area_reward") - pl.col(col)).sum().alias(f"return_schema_a_{beta:g}")
+        )
+    agg_exprs.append(
+        (pl.col("area_reward") - pl.col("energy_reward_schema_b")).sum().alias("return_schema_b")
+    )
+
+    returns = df_e18.group_by(["zone", "policy", "plant_id"]).agg(agg_exprs)
+    rdf = returns.to_pandas()
+
+    if rdf.empty:
+        print("No data found for Experiment 18.")
+        sys.exit(1)
+
+    # ── Zone energy: median daily energy × days (robust to outlier days) ─────
+    zone_energy = (
+        df_e18
+        .filter(pl.col("energy").is_not_null())
+        .group_by(["zone", "policy", "day"])
+        .agg(pl.col("energy").median().alias("daily_energy"))
+        .group_by(["zone", "policy"])
+        .agg(pl.col("daily_energy").sum().alias("total_energy"))
+    )
+    edf: dict[str, float] = dict(
+        zip(zone_energy["policy"].to_list(), zone_energy["total_energy"].to_list())
+    )
+
+    policies = [p for p in rdf["policy"].unique() if p in edf]
+    policy_order = sorted(policies, key=lambda p: edf[p])
+    policy_labels = [policy_label(p) for p in policy_order]
+    policy_to_y = {p: i for i, p in enumerate(policy_order)}
+
+    palette = _build_palette(len(policy_order))
+    color_map = dict(zip(policy_order, palette))
+
+    # Main return column: combined RL reward (area_reward − energy_reward_a_1)
+    return_col = "reward_return"
+
+    per_policy_pct = (
+        rdf.groupby("policy", as_index=False)[return_col]
+        .agg(
+            p_lo=lambda s: percentile_bounds(s.to_numpy(), TRIM_LO_PCT, TRIM_HI_PCT)[0],
+            p_hi=lambda s: percentile_bounds(s.to_numpy(), TRIM_LO_PCT, TRIM_HI_PCT)[1],
+        )
+    )
+    rdf = rdf.merge(per_policy_pct, on="policy", how="left")
+    rdf["outlier"] = (rdf[return_col] < rdf["p_lo"]) | (rdf[return_col] > rdf["p_hi"])
+    rdf["y_idx"] = rdf["policy"].map(policy_to_y)
+
+    const_policy = E18_POLICY_MAP[11]
+    const_energy = edf.get(const_policy)
+    const_return_df = rdf[rdf["policy"] == const_policy]
+    const_return = (
+        inner_percentile_mean(const_return_df[return_col].to_numpy(), TRIM_LO_PCT, TRIM_HI_PCT)
+        if not const_return_df.empty else None
+    )
+
+    summary = []
+    for policy in policy_order:
+        p_df = rdf[rdf["policy"] == policy]
+        if p_df.empty:
+            continue
+        mean_ret, ret_lo, ret_hi = inner_percentile_mean_ci(
+            p_df[return_col].to_numpy(), TRIM_LO_PCT, TRIM_HI_PCT,
+        )
+        summary.append({
+            "policy": policy,
+            "return_mean": mean_ret,
+            "return_ci_lo": ret_lo,
+            "return_ci_hi": ret_hi,
+            "energy": edf[policy],
+        })
+    s_df = pd.DataFrame(summary)
+
+    # ── Layout ────────────────────────────────────────────────────────────────
+    sns.set_theme(style="white")
+    fig = plt.figure(figsize=(10, 5.5), constrained_layout=True)
+    fig.get_layout_engine().set(h_pad=0.02, w_pad=0.02, hspace=0, wspace=0)
+    gs_main = fig.add_gridspec(1, 2, width_ratios=[2.5, 1.35], wspace=0.35)
+    gs_a = gs_main[0, 0].subgridspec(1, 2, wspace=0.12, width_ratios=[1.15, 1.0])
+    ax_energy = fig.add_subplot(gs_a[0, 0])
+    ax_return = fig.add_subplot(gs_a[0, 1])
+    ax_tradeoff = fig.add_subplot(gs_main[0, 1])
+
+    y_pos = np.arange(len(policy_order))
+
+    # ── Panel A1: Energy bars ─────────────────────────────────────────────────
+    ax_energy.barh(
+        y_pos, [edf[p] for p in policy_order], height=0.72,
+        color=[color_map[p] for p in policy_order],
+    )
+    if const_energy:
+        ax_energy.axvline(const_energy, color="#888888", linestyle="--", linewidth=1.4,
+                          zorder=0, label="Constant")
+    ax_energy.set_yticks(y_pos)
+    ax_energy.set_yticklabels(policy_labels, fontsize=10)
+    ax_energy.tick_params(axis="y", pad=6)
+    ax_energy.invert_yaxis()
+    ax_energy.set_ylim(len(policy_order) - 0.5, -0.5)
+    ax_energy.set_xlabel("Energy (Wh)", fontsize=11)
+    ax_energy.set_ylabel("Agent", fontsize=11, rotation=0, ha="right", va="center")
+    sns.despine(ax=ax_energy, right=True, top=True)
+    ax_energy.set_yticks(y_pos)
+    ax_energy.set_yticklabels(policy_labels, fontsize=10)
+
+    # ── Panel A2: Violin (reward_return distribution + mean ± 95% CI) ─────────
+    rdf_clean = rdf[~rdf["outlier"]]
+    sns.violinplot(
+        data=rdf_clean, y="y_idx", x=return_col, hue="policy", hue_order=policy_order,
+        palette=color_map, dodge=False, legend=False,
+        ax=ax_return, inner=None, density_norm="width", orient="h",
+    )
+    sns.stripplot(
+        data=rdf_clean, y="y_idx", x=return_col, order=y_pos,
+        color="0.3", alpha=0.12, jitter=0.2, size=2.5,
+        ax=ax_return, zorder=2, orient="h",
+    )
+    half_cap, half_mean, lw = 0.20, 0.14, 2.0
+    for policy in policy_order:
+        row = s_df[s_df["policy"] == policy]
+        if row.empty:
+            continue
+        row = row.iloc[0]
+        i = policy_to_y[policy]
+        ax_return.hlines(i, row["return_ci_lo"], row["return_ci_hi"],
+                         colors="black", linewidth=lw * 0.7, zorder=7)
+        ax_return.vlines(row["return_ci_lo"], i - half_cap, i + half_cap,
+                         colors="black", linewidth=lw, zorder=8)
+        ax_return.vlines(row["return_ci_hi"], i - half_cap, i + half_cap,
+                         colors="black", linewidth=lw, zorder=8)
+        ax_return.vlines(row["return_mean"], i - half_mean, i + half_mean,
+                         colors="black", linewidth=lw * 1.2, zorder=9)
+    if const_return is not None:
+        ax_return.axvline(const_return, color="#888888", linestyle="--", linewidth=1.4, zorder=0)
+    if ax_return.get_legend():
+        ax_return.get_legend().remove()
+    ax_return.set_xlabel("Return (area − β·ΔlogE, β=1)", fontsize=11, rotation=0)
+    ax_return.set_ylabel("")
+    ax_return.set_yticks(y_pos)
+    ax_return.set_yticklabels([])
+    ax_return.tick_params(axis="y", left=False, labelleft=False, length=0)
+    ax_return.set_ylim(len(policy_order) - 0.5, -0.5)
+    sns.despine(ax=ax_return, left=True, right=True, top=True)
+
+    # ── Panel B: Trade-off scatter (energy vs reward_return) ─────────────────
+    plot_tradeoff_panel(ax_tradeoff, s_df, color_map, const_return=const_return)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+    print(f"Saved return and energy plot to {out_path}")
+
+    plot_schema_returns_figure(
+        rdf, edf, policy_order, color_map, const_policy, Path(args.out_schemas),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/plot_e18_reward_with_energy.py
+++ b/visualization/plot_e18_reward_with_energy.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Analyze reward-with-energy schemas for Experiment 18.
+
+Schema A (log-energy penalty):
+    return' = return - β * (log E_policy - log E_Constant)
+
+Schema B (beat-Constant gate):
+    return' = -E_policy                         if return >= 0.9 * return_Constant
+              -fail_mult * max(E)               otherwise
+"""
+
+SCHEMA_B_FAIL_ENERGY_MULT = 2.0
+SCHEMA_B_GROWTH_FRAC = 0.95
+SCHEMA_A_BETAS = [0.0, 0.5, 1.0, 2.0]
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+import seaborn as sns
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from config import E18_POLICY_MAP, VERSION
+
+
+def inner_percentile_mean(x: np.ndarray, pct: float = 95) -> float:
+    x = np.asarray(x, dtype=float)
+    if len(x) == 0:
+        return 0.0
+    if len(x) == 1:
+        return float(x[0])
+    lo_pct = (100 - pct) / 2
+    hi_pct = 100 - lo_pct
+    lo, hi = np.percentile(x, [lo_pct, hi_pct])
+    trimmed = x[(x >= lo) & (x <= hi)]
+    if len(trimmed) == 0:
+        trimmed = x
+    return float(trimmed.mean())
+
+
+def pareto_frontier(df: pd.DataFrame, x: str, y: str) -> pd.DataFrame:
+    s = df.sort_values(x)
+    rows, max_y = [], -np.inf
+    for _, row in s.iterrows():
+        if row[y] > max_y:
+            rows.append(row)
+            max_y = row[y]
+    return pd.DataFrame(rows)
+
+
+def load_e18_summary(parquet: str, max_day: int) -> tuple[pd.DataFrame, float, float]:
+    df = pl.read_parquet(parquet)
+    df_e18 = df.filter(pl.col("experiment") == 18).with_columns(
+        pl.col("zone").replace_strict(E18_POLICY_MAP, default="Unknown").alias("policy")
+    )
+    df_e18 = df_e18.filter(
+        (pl.col("policy") != "Unknown") & (pl.col("day") <= max_day)
+    )
+
+    returns = df_e18.group_by(["zone", "policy", "plant_id"]).agg(
+        pl.col("reward").sum().alias("raw_return"),
+    )
+    energy = (
+        df_e18.select("zone", "policy", "time", "cumulative_energy")
+        .unique(subset=["zone", "time"])
+        .group_by("zone", "policy")
+        .agg(pl.col("cumulative_energy").max().alias("energy"))
+    )
+    merged = returns.join(energy, on=["zone", "policy"]).to_pandas()
+
+    e_const = merged.loc[merged["policy"] == "Constant", "energy"].iloc[0]
+    r_const = inner_percentile_mean(
+        merged.loc[merged["policy"] == "Constant", "raw_return"].to_numpy()
+    )
+
+    rows = []
+    for policy in merged["policy"].unique():
+        sub = merged[merged["policy"] == policy]
+        rows.append({
+            "policy": policy,
+            "energy": sub["energy"].iloc[0],
+            "raw_return": inner_percentile_mean(sub["raw_return"].to_numpy()),
+            "log_energy_delta": np.log(sub["energy"].iloc[0]) - np.log(e_const),
+        })
+    return pd.DataFrame(rows), e_const, r_const
+
+
+def induced_return_schema_a(base: pd.DataFrame, beta: float) -> pd.Series:
+    return base["raw_return"] - beta * base["log_energy_delta"]
+
+
+def schema_b_fail_penalty(max_energy: float) -> float:
+    return -SCHEMA_B_FAIL_ENERGY_MULT * max_energy
+
+
+def schema_b_gate_threshold(r_const: float) -> float:
+    return SCHEMA_B_GROWTH_FRAC * r_const
+
+
+def schema_b_passed(base: pd.DataFrame, r_gate: float) -> pd.Series:
+    return base["raw_return"] >= r_gate
+
+
+def induced_return_schema_b(
+    base: pd.DataFrame, r_gate: float, fail_penalty: float | None = None
+) -> pd.Series:
+    if fail_penalty is None:
+        fail_penalty = schema_b_fail_penalty(base["energy"].max())
+    passed = schema_b_passed(base, r_gate)
+    return np.where(passed, -base["energy"], fail_penalty)
+
+
+def plot_schema_a_panel(ax, base, beta, palette, energy_label):
+    df = base.copy()
+    df["induced"] = induced_return_schema_a(df, beta)
+    pf = pareto_frontier(df, "energy", "induced")
+    for _, row in df.iterrows():
+        ax.scatter(
+            row["energy"], row["induced"],
+            color=palette[row["policy"]], s=80, zorder=3,
+        )
+    ax.plot(
+        pf["energy"], pf["induced"], color="#e74c3c", linestyle="--",
+        linewidth=2, alpha=0.85, zorder=1,
+    )
+    title = "Raw return (β=0)" if beta == 0 else f"Schema A: β={beta:g}"
+    ax.set_title(title, fontsize=11, fontweight="bold")
+    ax.set_xlabel(energy_label)
+    ax.set_ylabel("Induced return")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze reward-with-energy schemas for E18."
+    )
+    parser.add_argument(
+        "--parquet", "-p",
+        default=f"/data/plant-rl/offline/{VERSION}/mixed-{VERSION}.parquet",
+    )
+    parser.add_argument(
+        "--out", "-o", default="results/e18_reward_with_energy.png",
+    )
+    parser.add_argument("--max-day", type=int, default=13)
+    args = parser.parse_args()
+
+    base, e_const, r_const = load_e18_summary(args.parquet, args.max_day)
+    policy_order = [
+        E18_POLICY_MAP[z]
+        for z in [11, 3, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+        if E18_POLICY_MAP[z] in set(base["policy"])
+    ]
+    palette = dict(zip(policy_order, sns.color_palette("muted", len(policy_order))))
+    raw_pareto = pareto_frontier(base, "energy", "raw_return")
+    energy_label = "Energy (Wh)"
+    fail_penalty = schema_b_fail_penalty(base["energy"].max())
+    r_gate = schema_b_gate_threshold(r_const)
+
+    sns.set_theme(style="whitegrid")
+    fig = plt.figure(figsize=(20, 9))
+    gs = fig.add_gridspec(2, 4, height_ratios=[1.1, 1.0], hspace=0.35, wspace=0.3)
+
+    for i, beta in enumerate(SCHEMA_A_BETAS):
+        ax = fig.add_subplot(gs[0, i])
+        plot_schema_a_panel(ax, base, beta, palette, energy_label)
+
+    # Rank heatmap
+    ax_rank = fig.add_subplot(gs[1, 0:2])
+    rank_rows = []
+    for beta in SCHEMA_A_BETAS:
+        ind = induced_return_schema_a(base, beta)
+        ranks = pd.Series(ind.values, index=base["policy"]).rank(ascending=False, method="min")
+        for policy in policy_order:
+            rank_rows.append({"beta": beta, "policy": policy, "rank": ranks[policy]})
+    pivot = (
+        pd.DataFrame(rank_rows)
+        .pivot(index="policy", columns="beta", values="rank")
+        .reindex(policy_order)
+    )
+    sns.heatmap(
+        pivot, annot=True, fmt=".0f", cmap="RdYlGn_r", ax=ax_rank,
+        cbar_kws={"label": "Rank (1=best)"},
+    )
+    ax_rank.set_title("Schema A: rank vs β", fontweight="bold")
+    ax_rank.set_xlabel("β")
+    ax_rank.set_ylabel("Policy")
+
+    # Schema B
+    ax_b = fig.add_subplot(gs[1, 2:4])
+    df_b = base.copy()
+    df_b["passed"] = schema_b_passed(df_b, r_gate)
+    df_b["induced"] = induced_return_schema_b(df_b, r_gate, fail_penalty)
+    pf_b = pareto_frontier(df_b[df_b["passed"]], "energy", "induced")
+    for _, row in df_b.iterrows():
+        marker = "o" if row["passed"] else "x"
+        ax_b.scatter(
+            row["energy"], row["induced"], s=100,
+            color=palette[row["policy"]], marker=marker, zorder=3,
+        )
+        if row["passed"]:
+            ax_b.annotate(
+                row["policy"].replace("Sequence", "Seq."),
+                (row["energy"], row["induced"]),
+                fontsize=7, ha="center", va="top",
+            )
+    ax_b.axhline(
+        fail_penalty, color="0.5", linestyle=":", linewidth=1.5,
+        label=f"Fail penalty ({SCHEMA_B_FAIL_ENERGY_MULT:.0f}× max E)",
+    )
+    if not pf_b.empty:
+        ax_b.plot(
+            pf_b["energy"], pf_b["induced"], color="#e74c3c", linestyle="--",
+            linewidth=2, alpha=0.85, label="Pareto (pass only)",
+        )
+    ax_b.set_title(
+        f"Schema B: pass→−E, fail→{fail_penalty:.0f}\n"
+        f"(R ≥ {SCHEMA_B_GROWTH_FRAC:.0%} Constant = {r_gate:.3f})",
+        fontweight="bold",
+    )
+    ax_b.set_xlabel(energy_label)
+    ax_b.set_ylabel("Induced return")
+    ax_b.legend(fontsize=8, loc="lower left")
+
+    fig.suptitle(
+        "E18 reward-with-energy schemas",
+        fontsize=14, fontweight="bold", y=1.01,
+    )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200, bbox_inches="tight")
+    plt.close()
+    print(f"Saved to {out_path}")
+
+    print(f"\nConstant baseline: E={e_const:.1f} Wh, inner-95% return={r_const:.4f}")
+    print(f"Schema B gate: {SCHEMA_B_GROWTH_FRAC:.0%} Constant → R ≥ {r_gate:.4f}")
+    print(f"Raw Pareto: {list(raw_pareto['policy'])}")
+    print("\nSchema A rankings:")
+    for beta in SCHEMA_A_BETAS:
+        ind = induced_return_schema_a(base, beta)
+        top = pd.Series(ind.values, index=base["policy"]).sort_values(ascending=False).head(3)
+        print(f"  β={beta:g}: {', '.join(top.index)}")
+    print(f"\nSchema B (pass→−E, fail→{fail_penalty:.0f}):")
+    print(df_b.sort_values("induced", ascending=False)[
+        ["policy", "raw_return", "energy", "passed", "induced"]
+    ].to_string(index=False, float_format=lambda x: f"{x:.4f}"))
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/plot_zone_area_transition.py
+++ b/visualization/plot_zone_area_transition.py
@@ -1,0 +1,253 @@
+"""
+Plot per-zone area transition scatter: x = current area (cm^2), y = next area (cm^2).
+Input parquet stores clean_area in cm^2.
+For each zone, fit a linear model y = m*x + b and annotate slope/intercept.
+"""
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+
+from config import VERSION
+
+PARQUET_PATH = Path(f"/data/plant-rl/offline/{VERSION}/mixed-{VERSION}.parquet")
+OUTPUT_DIR = Path("results/zone_area_transition")
+RED_ZONES = [1, 2, 5, 6, 9, 10]
+BLUE_ZONES = [3, 4, 7, 8, 11, 12]
+
+
+def load_transitions(path: Path, exp_id: int, max_steps: int) -> pl.DataFrame:
+    df = pl.read_parquet(
+        path,
+        columns=["experiment", "zone", "plant_id", "wall_time", "clean_area"],
+    )
+    df = df.filter(pl.col("experiment") == exp_id)
+    df = df.sort("zone", "plant_id", "wall_time")
+
+    # Keep first max_steps rows per episode to match existing metric scripts.
+    df = df.with_columns(
+        pl.col("wall_time").rank("ordinal").over("zone", "plant_id").alias("_step")
+    )
+    df = df.filter(pl.col("_step") <= max_steps)
+
+    # Build (current_area, next_area) pairs within each plant trajectory.
+    df = df.with_columns(
+        pl.col("clean_area").alias("current_area"),
+        pl.col("clean_area").shift(-1).over(["zone", "plant_id"]).alias("next_area"),
+    )
+
+    df = df.filter(
+        pl.col("current_area").is_not_null()
+        & pl.col("next_area").is_not_null()
+        & (pl.col("current_area") > 0)
+        & (pl.col("next_area") > 0)
+    )
+
+    return df.select(["zone", "plant_id", "current_area", "next_area"])
+
+
+def fit_line(x: np.ndarray, y: np.ndarray) -> tuple[float, float, float]:
+    if len(x) < 2:
+        return float("nan"), float("nan"), float("nan")
+    slope, intercept = np.polyfit(x, y, 1)
+    y_hat = slope * x + intercept
+    ss_res = np.sum((y - y_hat) ** 2)
+    ss_tot = np.sum((y - np.mean(y)) ** 2)
+    r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 0 else float("nan")
+    return slope, intercept, r2
+
+
+def compute_grid(n: int) -> tuple[int, int]:
+    ncols = int(math.ceil(math.sqrt(n)))
+    nrows = int(math.ceil(n / ncols))
+    return nrows, ncols
+
+
+def draw_zone_plots(transitions: pl.DataFrame, output_dir: Path, exp_id: int):
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pdf = transitions.to_pandas()
+    zones = sorted(pdf["zone"].unique().tolist())
+
+    if not zones:
+        print(f"No transitions found for experiment {exp_id}.")
+        return
+
+    nrows, ncols = compute_grid(len(zones))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(5 * ncols, 4.5 * nrows), squeeze=False)
+    axes_flat = axes.flatten()
+
+    for idx, zone in enumerate(zones):
+        ax = axes_flat[idx]
+        zone_df = pdf[pdf["zone"] == zone]
+
+        x = zone_df["current_area"].to_numpy(dtype=float)
+        y = zone_df["next_area"].to_numpy(dtype=float)
+
+        ax.scatter(x, y, s=10, alpha=0.35, color="#1f77b4", edgecolors="none")
+
+        slope, intercept, r2 = fit_line(x, y)
+        if np.isfinite(slope) and np.isfinite(intercept):
+            x_line = np.linspace(np.min(x), np.max(x), 200)
+            y_line = slope * x_line + intercept
+            ax.plot(x_line, y_line, color="#d62728", linewidth=2.0)
+
+            txt = (
+                f"n={len(x)}\n"
+                f"slope={slope:.4f}\n"
+                f"intercept={intercept:.4f}\n"
+                f"R^2={r2:.4f}"
+            )
+        else:
+            txt = f"n={len(x)}\ninsufficient data"
+
+        ax.text(
+            0.03,
+            0.97,
+            txt,
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            fontsize=9,
+            bbox={"boxstyle": "round,pad=0.3", "fc": "white", "ec": "0.8", "lw": 0.8},
+        )
+
+        ax.set_title(f"Zone {zone}")
+        ax.set_xlabel("Current Area (cm^2)")
+        ax.set_ylabel("Next Area (cm^2)")
+        ax.grid(True, alpha=0.25)
+
+    for j in range(len(zones), len(axes_flat)):
+        axes_flat[j].set_visible(False)
+
+    fig.suptitle(f"Experiment {exp_id}: Current vs Next Plant Area by Zone", fontsize=14)
+    fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.97))
+
+    out_path = output_dir / f"e{exp_id}_zone_area_transition.png"
+    fig.savefig(out_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"Saved -> {out_path}")
+
+
+def draw_group_plots(transitions: pl.DataFrame, output_dir: Path, exp_id: int):
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pdf = transitions.to_pandas()
+    groups = [
+        ("Red Zones", RED_ZONES, "#d62728"),
+        ("Blue Zones", BLUE_ZONES, "#1f77b4"),
+    ]
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), squeeze=False)
+    axes_flat = axes.flatten()
+
+    for idx, (name, zones, color) in enumerate(groups):
+        ax = axes_flat[idx]
+        group_df = pdf[pdf["zone"].isin(zones)]
+
+        x = group_df["current_area"].to_numpy(dtype=float)
+        y = group_df["next_area"].to_numpy(dtype=float)
+
+        ax.scatter(x, y, s=9, alpha=0.28, color=color, edgecolors="none")
+
+        slope, intercept, r2 = fit_line(x, y)
+        if np.isfinite(slope) and np.isfinite(intercept):
+            x_line = np.linspace(np.min(x), np.max(x), 200)
+            y_line = slope * x_line + intercept
+            ax.plot(x_line, y_line, color="black", linewidth=2.0)
+            txt = (
+                f"zones={zones}\n"
+                f"n={len(x)}\n"
+                f"y = {slope:.4f}x + {intercept:.4f}\n"
+                f"R^2={r2:.4f}"
+            )
+        else:
+            txt = f"zones={zones}\nn={len(x)}\ninsufficient data"
+
+        ax.text(
+            0.03,
+            0.97,
+            txt,
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            fontsize=9,
+            bbox={"boxstyle": "round,pad=0.3", "fc": "white", "ec": "0.8", "lw": 0.8},
+        )
+
+        ax.set_title(name)
+        ax.set_xlabel("Current Area (cm^2)")
+        ax.set_ylabel("Next Area (cm^2)")
+        ax.grid(True, alpha=0.25)
+
+    fig.suptitle(
+        f"Experiment {exp_id}: Current vs Next Plant Area (Aggregated Zone Groups)",
+        fontsize=14,
+    )
+    fig.tight_layout(rect=(0.0, 0.0, 1.0, 0.95))
+
+    out_path = output_dir / f"e{exp_id}_zone_area_transition_red_blue.png"
+    fig.savefig(out_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+    print(f"Saved -> {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot per-zone scatter of current area vs next area and linear fits."
+        )
+    )
+    parser.add_argument("--parquet", type=str, default=str(PARQUET_PATH))
+    parser.add_argument("--output", type=str, default=str(OUTPUT_DIR))
+    parser.add_argument(
+        "--experiment",
+        type=str,
+        default="17",
+        help="Experiment ID to plot, or 'all' to run all experiments in the dataset.",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=14,
+        help="Maximum number of steps per plant trajectory.",
+    )
+    args = parser.parse_args()
+
+    parquet_path = Path(args.parquet)
+    output_dir = Path(args.output)
+
+    if args.experiment == "all":
+        exp_df = pl.read_parquet(parquet_path, columns=["experiment"])
+        exp_ids = sorted(exp_df["experiment"].unique().to_list())
+        print(f"Found experiments: {exp_ids}")
+    else:
+        exp_ids = [int(args.experiment)]
+
+    for exp_id in exp_ids:
+        print(f"\n{'=' * 60}")
+        print(f"Experiment {exp_id}")
+        print(f"{'=' * 60}")
+
+        transitions = load_transitions(parquet_path, exp_id, args.max_steps)
+        print(f"Loaded {len(transitions)} transitions from E{exp_id}")
+
+        if len(transitions) == 0:
+            print(f"No data for E{exp_id}, skipping.")
+            continue
+
+        draw_zone_plots(transitions, output_dir, exp_id)
+        draw_group_plots(transitions, output_dir, exp_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New E18 visualization suite: daily dataset verification, biomass validation, power/energy trade-offs, zone transitions
- `scripts/fit_intensity_power.py` and `scripts/create_anffany_v1.py` for derived datasets
- Extend `run_e18.py` for all 12 zones and 14-day horizon

**Stacked on:** E18 daily dataset PR

## Test plan
- [ ] `uv run python run_e18.py` (requires parquet at `/data/plant-rl/offline/v27/`)
- [ ] Spot-check output figures in `results/`

Made with [Cursor](https://cursor.com)