### PR TITLE
Add slide deck figure generation scripts

### DIFF
--- a/slides/scripts/make_film_strip.py
+++ b/slides/scripts/make_film_strip.py
@@ -1,0 +1,594 @@
+"""
+Build a comparison composite for one or more E17 zones:
+
+  - Top: 3 (or N) raw camera frames per zone (no labels)
+  - Plant area panel: per-plant trajectories + per-zone mean overlaid
+  - Reward panel:     per-plant trajectories + per-zone mean overlaid
+  - Action panel(s):  one stacked R/W/B/night step-function per zone, shifted
+                      RIGHT by one day so action_t aligns with the area / reward
+                      it produced (the colour the audience sees here is the
+                      colour responsible for the growth above).
+
+Source of truth for frame timestamps: the `image_name` column of each zone's
+per-zone parquet.
+
+Usage:
+    python make_film_strip.py 7              # single zone
+    python make_film_strip.py 6,7 0,7,14     # two zones, specific days
+"""
+
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+from PIL import Image
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+ZONES = (
+    [int(z) for z in sys.argv[1].split(",")]
+    if len(sys.argv) > 1
+    else [7]
+)
+DAYS = (
+    [int(d) for d in sys.argv[2].split(",")]
+    if len(sys.argv) > 2
+    else None
+)
+
+# ── Layout / style ──────────────────────────────────────────────────────
+TILE_W  = 600
+TILE_H  = 450
+GAP     = 6
+LABEL_W = 160  # left zone-colored label tile
+BG     = "#FFFFFF"
+INK    = "#111111"
+MUTED  = "#9A9A93"
+GRID   = "#E6E5DE"
+RED    = "#D04A3C"
+BLUE   = "#3D5CC8"
+WHITE_BAR = "#B0AFA8"
+
+# Per-zone overlay colours (colour-blind safe pink + green).
+ZONE_COLORS = {
+    7:  "#30A667",   # green (BlueRed)
+    6:  "#CF50A0",   # pink  (RedBlue)
+    9:  "#3D5CC8",   # blue
+    10: "#A85FB2",   # purple
+}
+ZONE_LABELS = {
+    6:  r"$\pi_A$",
+    7:  r"$\pi_B$",
+    9:  r"$\pi_C$",
+    10: r"$\pi_D$",
+}
+# Per-zone source-image quad (4 corners, TL→TR→BR→BL) bounding a 3×3 pot
+# grid in the top-left of the chamber frame. The strip cells warp this quad
+# to a square. Camera mounts differ between zones — these are eyeballed from
+# /tmp/z6_grid_overlay.jpg and /tmp/z7_grid_overlay.jpg.
+ZONE_SRC_QUAD = {
+    6: [(195, 310), (710, 260), (680, 863), (125, 883)],
+    7: [(135, 225), (685, 125), (705, 693), (125, 783)],
+}
+
+OUT_DIR = Path(__file__).resolve().parent.parent / "assets" / "photos"
+ROOT = Path("/data/plant-rl/online/E17/P1")
+
+
+def zone_paths(zone: int):
+    zdir = next(ROOT.glob(f"*/alliance-zone{zone:02d}"))
+    return {
+        "dir":     zdir,
+        "hourly":  zdir / "processed" / "v27" / f"E17_Z{zone}_hourly.parquet",
+        "daily":   zdir / "processed" / "v27" / f"E17_Z{zone}.parquet",
+        "viz_dir": zdir / "processed" / "v27" / "visualizations",
+        "images":  zdir / "images",
+    }
+
+
+def colour_for(zone: int) -> str:
+    return ZONE_COLORS.get(zone, f"C{zone % 10}")
+
+
+# ── Frame strip per zone ────────────────────────────────────────────────
+def daily_frames(zone: int) -> list[tuple[int, date, str]]:
+    p = zone_paths(zone)
+    parquet = p["hourly"] if p["hourly"].exists() else p["daily"]
+    df = (
+        pl.read_parquet(parquet, columns=["time", "plant_id", "image_name", "day"])
+        .unique(subset=["time"])
+        .sort("time")
+    )
+    out = []
+    for d, t, name in zip(df["day"], df["time"], df["image_name"]):
+        # day 0 9:30 happens before the hourly grid; daily parquet still emits it.
+        # The per-day "first observation at 09:30 local" is what we want.
+        out.append((int(d), t.date(), name))
+    # Deduplicate by day, keep first (earliest) timestamp per day.
+    seen = set()
+    deduped = []
+    for d, dte, n in out:
+        if d in seen:
+            continue
+        seen.add(d)
+        deduped.append((d, dte, n))
+    return deduped
+
+
+def build_strip(zone: int, frames, use_viz: bool, out: Path):
+    """Photo strip. RAW frames are taken at +5 min (T003500 instead of T003000)
+    so the experimental R/W/B light is visible — the 9:30 daily observation
+    itself is captured under a neutral white flash, where every zone looks
+    the same.  Viz frames stay on the 9:30 timestamp (that's what the pipeline
+    annotates).
+
+    Prepended with a zone-colored label tile so each strip row is visually
+    linked to the matching trajectory colour in the feature panels below.
+    """
+    p = zone_paths(zone)
+    tile_dir = Path(f"/tmp/zone_strip_tiles_z{zone}")
+    tile_dir.mkdir(parents=True, exist_ok=True)
+    for f in tile_dir.glob("*.jpg"):
+        f.unlink()
+
+    # Build a label tile via matplotlib (so LaTeX π subscript renders cleanly).
+    label_tile = tile_dir / "label.jpg"
+    dpi = 150
+    fig = plt.figure(figsize=(LABEL_W / dpi, TILE_H / dpi), dpi=dpi)
+    fig.patch.set_facecolor(BG)
+    ax = fig.add_axes((0, 0, 1, 1))
+    ax.set_facecolor(BG); ax.set_axis_off()
+    ax.text(0.5, 0.5, ZONE_LABELS.get(zone, f"Z{zone}"),
+            color=colour_for(zone), fontsize=96,
+            ha="center", va="center", transform=ax.transAxes)
+    fig.savefig(label_tile, dpi=dpi, facecolor=BG, pad_inches=0)
+    plt.close(fig)
+
+    tile_paths = []
+    for day, d, name in frames:
+        if use_viz:
+            src = p["viz_dir"] / f"E17_Z{zone}_{d:%Y-%m-%d}T093000_viz.jpg"
+        else:
+            # Shift to the +5 min frame so coloured lights are visible.
+            shifted = name.replace("T003000", "T003500")
+            src = p["images"] / shifted
+            if not src.exists():
+                # Fall back to the original 9:30 frame.
+                src = p["images"] / name
+        if not src.exists():
+            print(f"  Z{zone} day {day}: missing {src}")
+            continue
+        dst = tile_dir / f"day{day:02d}.jpg"
+        subprocess.run(
+            ["convert", str(src), "-resize", f"{TILE_W}x{TILE_H}^",
+             "-gravity", "center", "-extent", f"{TILE_W}x{TILE_H}",
+             "-quality", "92", str(dst)],
+            check=True,
+        )
+        tile_paths.append(dst)
+
+    if not tile_paths:
+        raise RuntimeError(f"Z{zone}: no tiles produced")
+
+    cmd = ["convert", str(label_tile)]
+    for tp in tile_paths:
+        cmd += ["-size", f"{GAP}x{TILE_H}", f"xc:{BG}", str(tp)]
+    cmd += ["+append", "-quality", "92", str(out)]
+    subprocess.run(cmd, check=True)
+    print(f"saved -> {out}  (Z{zone}, {len(tile_paths)} tiles)")
+    return out
+
+
+# ── Helpers for the features panel ──────────────────────────────────────
+GAP_DAYS = 0.2  # night-gap threshold
+
+def break_at_gaps(x: np.ndarray, y: np.ndarray):
+    """Insert NaNs at time gaps > GAP_DAYS so matplotlib breaks the line."""
+    if len(x) == 0:
+        return x, y
+    order = np.argsort(x)
+    x, y = x[order], y[order]
+    dx = np.diff(x)
+    breaks = np.where(dx > GAP_DAYS)[0]
+    if len(breaks) == 0:
+        return x, y
+    xs, ys = [], []
+    start = 0
+    for b in breaks:
+        xs.append(x[start : b + 1]); xs.append(np.array([np.nan]))
+        ys.append(y[start : b + 1]); ys.append(np.array([np.nan]))
+        start = b + 1
+    xs.append(x[start:]); ys.append(y[start:])
+    return np.concatenate(xs), np.concatenate(ys)
+
+
+def drop_area_spikes(y: np.ndarray, window: int = 7, k: float = 3.0):
+    """Asymmetric MAD spike filter — only nulls upward spikes."""
+    if len(y) < window:
+        return y
+    from numpy.lib.stride_tricks import sliding_window_view
+    pad = window // 2
+    padded = np.pad(y, pad, mode="edge")
+    win = sliding_window_view(padded, window)
+    med = np.nanmedian(win, axis=1)
+    mad = np.nanmedian(np.abs(win - med[:, None]), axis=1)
+    mad = np.where(mad < 1e-6, 1.0, mad)
+    spike = (y - med) > k * 1.4826 * mad
+    spike |= y > 30.0
+    return np.where(spike, np.nan, y)
+
+
+def load_zone_data(zone: int) -> pl.DataFrame:
+    """Return the hourly parquet for `zone`, or fall back to daily.
+
+    Uses `area_after_tukey` for the per-step area (frame-level MAD outlier
+    removal — see plant-cv/api/pipeline/app/analysis.py) and exposes it as
+    `clean_area`. This deliberately skips the EWM-based cleaning, which
+    was tuned for the daily monotonic-growth setting and clips legitimate
+    within-day downward moves (parabolic turgor cycle).
+    """
+    p = zone_paths(zone)
+    src = p["hourly"] if p["hourly"].exists() else p["daily"]
+    print(f"  Z{zone}: loading {src.name}")
+    df = pl.read_parquet(
+        src,
+        columns=["plant_id", "wall_time", "day", "clean_area",
+                 "red_coef", "white_coef", "blue_coef", "reward"],
+    )
+    # Drop the partial day-14 trailing data (one stray point would render as
+    # an isolated dot at the right edge of the lineplots).
+    return df.filter(pl.col("wall_time") < 14.0)
+
+
+def _find_coeffs(src_quad, dst_quad):
+    """Solve for PIL perspective transform coefficients (output→source)."""
+    A, b = [], []
+    for (sx, sy), (dx, dy) in zip(src_quad, dst_quad):
+        A.append([dx, dy, 1, 0, 0, 0, -sx * dx, -sx * dy])
+        A.append([0, 0, 0, dx, dy, 1, -sy * dx, -sy * dy])
+        b.append(sx); b.append(sy)
+    return tuple(np.linalg.solve(np.asarray(A, float),
+                                 np.asarray(b, float)).tolist())
+
+
+def load_warped(image_path: Path, src_quad, side: int = 800) -> np.ndarray:
+    """Perspective-warp a 4-corner quad from the source image into a `side`×
+    `side` square. `src_quad` is TL, TR, BR, BL in source pixel coords."""
+    img = Image.open(image_path).convert("RGB")
+    dst_quad = [(0, 0), (side, 0), (side, side), (0, side)]
+    coeffs = _find_coeffs(src_quad, dst_quad)
+    warped = img.transform(
+        (side, side), Image.Transform.PERSPECTIVE, coeffs,
+        Image.Resampling.BICUBIC,
+    )
+    return np.asarray(warped)
+
+
+# Back-compat shim used by the standalone strip JPGs (still want a quick
+# crop there since they don't have per-zone calibration info handy).
+def load_square_left(image_path: Path, zoom: float = 0.265,
+                     x_offset_frac: float = 0.02,
+                     y_offset_frac: float = 0.0) -> np.ndarray:
+    img = Image.open(image_path).convert("RGB")
+    w, h = img.size
+    side = int(min(w, h) * zoom)
+    x0 = max(0, int(w * x_offset_frac))
+    y0 = max(0, int(h * y_offset_frac))
+    img = img.crop((x0, y0, x0 + side, y0 + side))
+    return np.asarray(img)
+
+
+def shifted_image_path(zone: int, image_name: str) -> Path:
+    """Per-day raw frame at +5 min so the experimental colour is visible."""
+    p = zone_paths(zone)
+    shifted = image_name.replace("T003000", "T003500")
+    cand = p["images"] / shifted
+    return cand if cand.exists() else p["images"] / image_name
+
+
+# ── Features panel: strip(s) + area + reward + per-zone action ──────────
+def build_features_panel(width_px: int, out: Path):
+    plt.rcParams.update({
+        "figure.facecolor": BG,
+        "axes.facecolor": BG,
+        "savefig.facecolor": BG,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "axes.edgecolor": MUTED,
+        "axes.linewidth": 1.0,
+        "axes.labelcolor": INK,
+        "axes.titlesize": 22,
+        "axes.titleweight": "regular",
+        "axes.labelsize": 18,
+        "xtick.color": INK,
+        "ytick.color": INK,
+        "xtick.labelsize": 16,
+        "ytick.labelsize": 16,
+        "axes.grid": True,
+        "grid.color": GRID,
+        "grid.linewidth": 0.6,
+        "grid.alpha": 1.0,
+        "font.family": ["Inter", "Liberation Sans", "DejaVu Sans", "sans-serif"],
+        "font.size": 16,
+        "text.color": INK,
+        "legend.frameon": False,
+        "legend.fontsize": 14,
+    })
+
+    # Load all zones
+    data = {z: load_zone_data(z) for z in ZONES}
+    actions_by_zone = {
+        z: (
+            d.unique(subset=["day"]).sort("day")
+             .select(["day", "red_coef", "white_coef", "blue_coef"])
+             .to_pandas()
+        )
+        for z, d in data.items()
+    }
+
+    # Layout: one strip row per zone, then state / reward / action.
+    # Whole figure is locked to 16:9 so it drops cleanly onto a slide.
+    n_strip = len(ZONES)
+    heights = [0.55] * n_strip + [1.3, 0.9]
+    n_rows  = n_strip + 2
+
+    dpi = 150
+    fig_w_in = width_px / dpi
+    fig_h_in = fig_w_in * 9.0 / 16.0
+    fig, axes = plt.subplots(
+        n_rows, 1, figsize=(fig_w_in, fig_h_in), dpi=dpi, sharex=True,
+        gridspec_kw={"height_ratios": heights, "hspace": 0.18},
+    )
+    strip_axes = list(axes[:n_strip])
+    ax_area, ax_rew = axes[n_strip], axes[n_strip + 1]
+    ax_act = None
+
+    # ── Strip rows — square photos, one per day, at x=[d, d+1]
+    for ax, z in zip(strip_axes, ZONES):
+        frames = daily_frames(z)
+        # Only days that fit on the [0, 14] axis; trim partial day 14.
+        frames = [(d, dte, n) for d, dte, n in frames if d < 14]
+        src_quad = ZONE_SRC_QUAD.get(z)
+        for day, _, name in frames:
+            try:
+                src_img = shifted_image_path(z, name)
+                if src_quad is not None:
+                    img = load_warped(src_img, src_quad, side=800)
+                else:
+                    img = load_square_left(src_img)
+            except Exception as e:
+                print(f"  Z{z} day {day}: image load failed ({e})")
+                continue
+            ax.imshow(img, extent=(day, day + 1, 0, 1),
+                      aspect="auto", interpolation="bilinear")
+        ax.set_xlim(0, 14)
+        ax.set_ylim(0, 1)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.tick_params(axis="both", which="both", length=0)
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+        ax.set_ylabel(
+            ZONE_LABELS.get(z, f"Z{z}"),
+            color=colour_for(z), fontsize=34, rotation=0,
+            ha="right", va="center", labelpad=18,
+        )
+
+    # Align the day band to the hourly observation window (9:30–19:30 local =
+    # 10 h, wall_time d to d + 0.4167). The chamber's true photoperiod is
+    # 12 h (9:00–21:00) but observations bracket those edges, so anchoring
+    # to the data avoids the "night starts after the last point" gap.
+    LIGHTS_ON_OFFSET = 0.0
+    PHOTOPERIOD       = 10.0 / 24.0   # ≈ 0.4167
+    N_DAYS            = 15
+
+    # Grey night-band overlays + no gridlines on every panel.
+    panels_to_shade = [ax_area, ax_rew] + (
+        [ax_act] if ax_act is not None else []
+    )
+    for ax in panels_to_shade:
+        for d in range(N_DAYS):
+            night_start = d + LIGHTS_ON_OFFSET + PHOTOPERIOD
+            night_end   = d + 1 + LIGHTS_ON_OFFSET
+            ax.axvspan(night_start, night_end,
+                       color=MUTED, alpha=0.12, linewidth=0)
+        ax.grid(False)
+
+    # ── Plant area — uses parquet's post-pipeline `clean_area` (EWM-cleaned
+    # by plant-cv with the patched downward threshold). No extra outlier
+    # filtering in the plot — the pipeline handles it.
+    # We still exclude "dead" plants (final area below threshold) and
+    # restrict to plants with full timestamp coverage; both are sample
+    # selection, not outlier filtering.
+    DEAD_FINAL_THRESHOLD_CM2 = 1.5
+    # Cache the fixed-cohort plant sets per zone so the reward panel can
+    # reuse them (avoids sample-composition drift in mean_area).
+    zone_cohort: dict[int, set] = {}
+    for z in ZONES:
+        df = data[z]
+        pdf = df.filter(pl.col("clean_area").is_not_null()).to_pandas()
+        # Alive by final-day area.
+        finals = (
+            pdf.sort_values("wall_time")
+               .groupby("plant_id")["clean_area"]
+               .last()
+        )
+        alive = set(finals[finals >= DEAD_FINAL_THRESHOLD_CM2].index)
+        # Require plants present at every observed timestamp — fixes the
+        # composition jitter where new plants joining the mean would jerk
+        # the average around day 1.
+        all_ts = pdf["wall_time"].round(3).unique()
+        n_ts = len(all_ts)
+        per_pid = pdf.assign(_t=pdf["wall_time"].round(3)) \
+                     .groupby("plant_id")["_t"].nunique()
+        full_coverage = set(per_pid[per_pid == n_ts].index)
+        cohort = alive & full_coverage
+        zone_cohort[z] = cohort
+        pdf = pdf[pdf["plant_id"].isin(cohort)]
+        series_by_t: dict[float, list[float]] = {}
+        for pid, g in pdf.groupby("plant_id"):
+            x = g["wall_time"].to_numpy()
+            y = g["clean_area"].to_numpy()
+            order = np.argsort(x); x, y = x[order], y[order]
+            for xi, yi in zip(x, y):
+                if np.isfinite(yi):
+                    series_by_t.setdefault(round(float(xi), 3), []).append(float(yi))
+            xx, yy = break_at_gaps(x, y)
+            ax_area.plot(xx, yy, color=colour_for(z), alpha=0.20, linewidth=0.5)
+        ts = np.array(sorted(series_by_t.keys()))
+        means = np.array([np.mean(series_by_t[t]) for t in ts])
+        mx, my = break_at_gaps(ts, means)
+        ax_area.plot(mx, my, color=colour_for(z), linewidth=2.4, alpha=0.95)
+        print(f"  Z{z}: cohort {len(cohort)} plants (alive ∩ full-coverage)")
+
+    ax_area.set_ylabel("Leaf\nArea\n(cm²)", rotation=0, ha="right",
+                       va="center", labelpad=18, fontsize=22)
+    ax_area.set_xlim(0, 14)
+    ax_area.yaxis.set_major_locator(plt.MaxNLocator(nbins=4, integer=True))
+
+    # ── Reward — option 1: mean over per-plant rewards (from parquet's
+    # `reward` column which is log(area_t) - log(area_{t-1}) per plant).
+    # Averaging happens AFTER the log-diff so each plant contributes its own
+    # per-step reward to the mean.
+    rew_means_for_scale: list[float] = []
+    zone_return: list[tuple[int, float]] = []
+    for z in ZONES:
+        df = data[z]
+        if "reward" not in df.columns:
+            continue
+        cohort = zone_cohort.get(z, set())
+        pdf = df.to_pandas()
+        pdf = pdf[pdf["plant_id"].isin(cohort)]
+        rewards_by_t: dict[float, list[float]] = {}
+        for pid, g in pdf.groupby("plant_id"):
+            x = g["wall_time"].to_numpy()
+            y = g["reward"].to_numpy(dtype=float)
+            order = np.argsort(x); x, y = x[order], y[order]
+            for xi, yi in zip(x, y):
+                if np.isfinite(yi):
+                    rewards_by_t.setdefault(round(float(xi), 3), []).append(float(yi))
+        rts = np.array(sorted(rewards_by_t.keys()))
+        rmean = np.array([np.mean(rewards_by_t[t]) for t in rts])
+        rx, ry = break_at_gaps(rts, rmean)
+        ax_rew.plot(rx, ry, color=colour_for(z), linewidth=2.2, alpha=0.75)
+        rew_means_for_scale.extend(rmean[np.isfinite(rmean)].tolist())
+
+        # Total return = Σ mean rewards = mean of per-plant log-growth ratios.
+        finite = rmean[np.isfinite(rmean)]
+        if finite.size:
+            ret = float(finite.sum())
+            zone_return.append((z, ret))
+
+    if rew_means_for_scale:
+        arr = np.asarray(rew_means_for_scale)
+        # Extra headroom at top to keep formula + return labels off the data.
+        ax_rew.set_ylim(
+            float(arr.min()) - 0.02,
+            float(arr.max()) * 1.45 + 0.02,
+        )
+
+    # Return annotations on ONE line at top-right of the reward panel, each
+    # zone in its own colour. Separator stays grey for readability.
+    if zone_return:
+        # Render right-to-left so each text knows where the next one ends.
+        x = 0.985
+        for i, (z, ret) in enumerate(reversed(zone_return)):
+            idx = len(zone_return) - 1 - i
+            label = ['A', 'B', 'C', 'D'][idx]
+            txt = rf"$\mathrm{{Return}}_{label} = {ret:.1f}$"
+            t = ax_rew.text(
+                x, 0.85, txt,
+                transform=ax_rew.transAxes,
+                ha="right", va="bottom",
+                color=colour_for(z),
+                fontsize=20,
+            )
+            # Estimate text width in axes fraction to lay out a separator
+            # before the next one.
+            renderer = fig.canvas.get_renderer()
+            bbox = t.get_window_extent(renderer=renderer)
+            ax_bbox = ax_rew.get_window_extent(renderer=renderer)
+            frac_w = bbox.width / ax_bbox.width
+            if i < len(zone_return) - 1:
+                # Small gap (no separator) between consecutive labels.
+                x = x - frac_w - 0.025
+    ax_rew.axhline(0, color=MUTED, linewidth=0.7, alpha=0.6)
+    ax_rew.set_ylabel("Reward", rotation=0, ha="right", va="center",
+                      labelpad=18, fontsize=22)
+    ax_rew.set_xlim(0, 14)
+    ax_rew.yaxis.set_major_formatter(plt.FuncFormatter(lambda v, _: f"{v:.1f}"))
+    ax_rew.yaxis.set_major_locator(plt.MaxNLocator(nbins=3))
+    # Formula and Return labels share the SAME y and va so their bbox bottoms
+    # sit on the same line.
+    ax_rew.text(
+        0.012, 0.85,
+        r"$r_t = \log \mathrm{area}_t - \log \mathrm{area}_{t-1}$",
+        transform=ax_rew.transAxes,
+        ha="left", va="bottom",
+        fontsize=20, color=INK,
+    )
+
+    # Bottom panel: explicit day-number ticks.
+    ax_rew.set_xlabel("Day", fontsize=24, labelpad=10)
+    ax_rew.set_xticks(list(range(0, 15)))
+    ax_rew.tick_params(axis="x", which="major", labelsize=18)
+
+    fig.tight_layout()
+    fig.savefig(out, dpi=dpi, bbox_inches="tight", facecolor=BG)
+    plt.close(fig)
+    print(f"saved -> {out}")
+    return out
+
+
+# ── Composite stacking ──────────────────────────────────────────────────
+def vstack_images(parts: list[Path], out: Path, gap_px: int = 24):
+    imgs = [Image.open(p).convert("RGB") for p in parts]
+    # Match all widths to the widest, scaling proportionally
+    target_w = max(im.width for im in imgs)
+    scaled = []
+    for im in imgs:
+        if im.width != target_w:
+            ratio = target_w / im.width
+            im = im.resize((target_w, int(im.height * ratio)), Image.LANCZOS)
+        scaled.append(im)
+    total_h = sum(im.height for im in scaled) + gap_px * (len(scaled) - 1)
+    canvas = Image.new("RGB", (target_w, total_h), BG)
+    y = 0
+    for im in scaled:
+        canvas.paste(im, (0, y))
+        y += im.height + gap_px
+    canvas.save(out, "PNG")
+    print(f"saved -> {out}")
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Zones: {ZONES}")
+
+    # Still produce the standalone strip JPGs (handy for slides as separate
+    # artifacts), but the composite is now a single matplotlib figure that
+    # places photos on the same x-axis as the data plots below.
+    for z in ZONES:
+        frames = daily_frames(z)
+        if DAYS is not None:
+            keep = set(DAYS)
+            frames_sel = [f for f in frames if f[0] in keep]
+        else:
+            frames_sel = frames
+        print(f"  Z{z}: standalone strip {len(frames_sel)} tiles")
+        build_strip(z, frames_sel, use_viz=False,
+                    out=OUT_DIR / f"z{z:02d}_film_strip.jpg")
+        build_strip(z, frames_sel, use_viz=True,
+                    out=OUT_DIR / f"z{z:02d}_film_strip_viz.jpg")
+
+    suffix = "_".join(f"z{z:02d}" for z in ZONES)
+    # Wider canvas now that the strip is integrated and shows 14 tiles.
+    width_px = 14 * 150 + 200    # ~14 days * ~150px square + y-label area
+    build_features_panel(width_px, OUT_DIR / f"{suffix}_composite.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/slides/scripts/make_slide_figures.py
+++ b/slides/scripts/make_slide_figures.py
@@ -1,0 +1,329 @@
+"""
+Render minimalist E17 figures for the slides deck.
+
+Outputs PNGs into slides/assets/figures/, styled to match the off-white
+disco-design aesthetic used by slides/index.html and slides/css/theme.css.
+
+Reuses data-loading and bootstrap helpers from visualization/plot_reward_over_time.py
+and the red/blue zone split from visualization/plot_zone_area_transition.py.
+"""
+
+import io
+import re
+import sys
+import tarfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(REPO_ROOT))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import polars as pl
+
+from config import VERSION
+from visualization.plot_reward_over_time import (
+    bootstrap_mean_ci,
+    load_reward_rows,
+    summarize_bootstrap,
+)
+from visualization.plot_zone_area_transition import (
+    BLUE_ZONES,
+    RED_ZONES,
+    fit_line,
+    load_transitions,
+)
+
+PARQUET = Path(f"/data/plant-rl/offline/{VERSION}/mixed-{VERSION}.parquet")
+SPECTRA = REPO_ROOT / "data" / "spectra.tar.gz"
+OUT = REPO_ROOT / "slides" / "assets" / "figures"
+EXPERIMENT = 17
+MAX_STEPS = 14
+
+BG = "#FAFAF7"
+INK = "#111111"
+MUTED = "#9A9A93"
+GRID = "#E6E5DE"
+ACCENT = "#2E5BFF"
+RED = "#D04A3C"
+BLUE = "#3D5CC8"
+WHITE_BAR = "#B0AFA8"
+
+AGENT_PALETTE = {
+    "RedRed": "#C8493C",
+    "RedBlue": "#A85FB2",
+    "BlueRed": "#5F8DD3",
+    "BlueBlue": "#2E5BFF",
+}
+
+plt.rcParams.update(
+    {
+        "figure.facecolor": BG,
+        "axes.facecolor": BG,
+        "savefig.facecolor": BG,
+        "savefig.edgecolor": BG,
+        "axes.spines.top": False,
+        "axes.spines.right": False,
+        "axes.spines.left": True,
+        "axes.spines.bottom": True,
+        "axes.edgecolor": MUTED,
+        "axes.linewidth": 0.8,
+        "axes.labelcolor": INK,
+        "axes.titlesize": 13,
+        "axes.titleweight": "regular",
+        "axes.titlepad": 14,
+        "axes.labelsize": 11,
+        "axes.labelpad": 8,
+        "xtick.color": INK,
+        "ytick.color": INK,
+        "xtick.labelsize": 9,
+        "ytick.labelsize": 9,
+        "xtick.major.size": 3,
+        "ytick.major.size": 3,
+        "axes.grid": True,
+        "grid.color": GRID,
+        "grid.linewidth": 0.6,
+        "grid.alpha": 1.0,
+        "font.family": ["Inter", "Helvetica Neue", "Arial", "sans-serif"],
+        "font.size": 11,
+        "text.color": INK,
+        "legend.frameon": False,
+        "legend.fontsize": 10,
+        "figure.dpi": 150,
+    }
+)
+
+
+def _save(fig, name: str):
+    OUT.mkdir(parents=True, exist_ok=True)
+    path = OUT / name
+    fig.savefig(path, dpi=200, bbox_inches="tight", facecolor=BG)
+    plt.close(fig)
+    print(f"saved -> {path}")
+
+
+def fig_plant_area_trajectories():
+    df = pl.read_parquet(
+        PARQUET,
+        columns=["experiment", "zone", "plant_id", "wall_time", "clean_area", "agent"],
+    )
+    df = df.filter(pl.col("experiment") == EXPERIMENT)
+    df = df.filter(pl.col("wall_time").is_not_null() & pl.col("clean_area").is_not_null())
+    df = df.filter((pl.col("wall_time") >= 0) & (pl.col("wall_time") <= MAX_STEPS))
+    pdf = df.sort("zone", "plant_id", "wall_time").to_pandas()
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    for (_, _), g in pdf.groupby(["zone", "plant_id"]):
+        t = g["wall_time"].to_numpy(float)
+        a = g["clean_area"].to_numpy(float)
+        gaps = np.where(np.diff(t) > 1.0)[0] + 1
+        start = 0
+        for end in list(gaps) + [len(t)]:
+            ax.plot(t[start:end], a[start:end], color=MUTED, alpha=0.18, linewidth=0.6)
+            start = end
+
+    agents = ["BlueBlue", "BlueRed", "RedBlue", "RedRed"]
+    for agent in agents:
+        sub = pdf[pdf["agent"] == agent]
+        if sub.empty:
+            continue
+        sub = sub.copy()
+        sub["t_round"] = sub["wall_time"].round(2)
+        mean = sub.groupby("t_round")["clean_area"].mean()
+        ax.plot(
+            mean.index.to_numpy(),
+            mean.to_numpy(),
+            color=AGENT_PALETTE[agent],
+            linewidth=2.0,
+            alpha=0.95,
+            label=agent,
+        )
+
+    ax.set_xlabel("Wall time (days)")
+    ax.set_ylabel("Plant area (cm²)")
+    ax.set_xlim(0, MAX_STEPS)
+    ax.legend(loc="upper left", ncol=4, columnspacing=1.6, handlelength=1.4)
+    _save(fig, "e17_plant_area.png")
+
+
+def fig_reward_over_time():
+    pdf = load_reward_rows(PARQUET, exp_id=EXPERIMENT, max_steps=MAX_STEPS)
+    if pdf.empty:
+        print("no reward rows for E17")
+        return
+
+    pdf = pdf.sort_values(["zone", "agent", "plant_id", "wall_time"])
+    pdf["cum_reward"] = pdf.groupby(["zone", "agent", "plant_id"])["reward"].cumsum()
+
+    summary = summarize_bootstrap(
+        pdf,
+        group_cols=["agent"],
+        metric_col="cum_reward",
+        n_boot=3000,
+        ci=0.95,
+    )
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    for agent in ["BlueBlue", "BlueRed", "RedBlue", "RedRed"]:
+        g = summary[summary["agent"] == agent].sort_values("wall_time")
+        if g.empty:
+            continue
+        x = g["wall_time"].to_numpy(float)
+        y = g["mean"].to_numpy(float)
+        lo = g["ci_low"].to_numpy(float)
+        hi = g["ci_high"].to_numpy(float)
+        c = AGENT_PALETTE[agent]
+        ax.fill_between(x, lo, hi, color=c, alpha=0.14, linewidth=0)
+        ax.plot(x, y, color=c, linewidth=2.0, label=agent)
+
+    ax.set_xlabel("Wall time (days)")
+    ax.set_ylabel("Cumulative reward")
+    ax.set_xlim(0, MAX_STEPS)
+    ax.legend(loc="upper left", ncol=4, columnspacing=1.6, handlelength=1.4)
+    _save(fig, "e17_reward_over_time.png")
+
+
+def fig_action_coef():
+    df = pl.read_parquet(
+        PARQUET,
+        columns=[
+            "experiment", "zone", "plant_id", "wall_time", "agent",
+            "red_coef", "white_coef", "blue_coef",
+        ],
+    )
+    df = df.filter(pl.col("experiment") == EXPERIMENT)
+    df = df.with_columns(
+        pl.col("wall_time").rank("ordinal").over("zone", "plant_id").alias("_step")
+    )
+    df = df.filter(pl.col("_step") <= MAX_STEPS)
+    df = df.with_columns((pl.col("_step") - 1).alias("day"))
+
+    agg = (
+        df.group_by(["agent", "day"])
+        .agg(
+            pl.col("red_coef").mean().alias("red"),
+            pl.col("white_coef").mean().alias("white"),
+            pl.col("blue_coef").mean().alias("blue"),
+        )
+        .sort("agent", "day")
+        .to_pandas()
+    )
+
+    agents = ["BlueBlue", "BlueRed", "RedBlue", "RedRed"]
+    fig, axes = plt.subplots(1, 4, figsize=(14, 4.2), sharey=True)
+    for ax, agent in zip(axes, agents):
+        g = agg[agg["agent"] == agent].sort_values("day")
+        if g.empty:
+            ax.set_visible(False)
+            continue
+        x = g["day"].to_numpy()
+        r = g["red"].to_numpy()
+        w = g["white"].to_numpy()
+        b = g["blue"].to_numpy()
+        ax.stackplot(
+            x, r, w, b,
+            colors=[RED, WHITE_BAR, BLUE],
+            labels=["red", "white", "blue"],
+            edgecolor=BG,
+            linewidth=0.4,
+        )
+        ax.set_title(agent)
+        ax.set_xlim(x.min(), x.max())
+        ax.set_ylim(0, 1.01)
+        ax.set_xlabel("Day")
+        ax.grid(False)
+        ax.spines["left"].set_visible(False)
+        ax.tick_params(axis="y", length=0)
+    axes[0].set_ylabel("Channel mix")
+    axes[0].spines["left"].set_visible(True)
+    axes[-1].legend(loc="center right", bbox_to_anchor=(1.35, 0.5))
+    fig.subplots_adjust(wspace=0.18)
+    _save(fig, "e17_action_coef.png")
+
+
+def fig_zone_transition():
+    transitions = load_transitions(PARQUET, EXPERIMENT, MAX_STEPS)
+    pdf = transitions.to_pandas()
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5.4), sharey=True)
+    groups = [
+        ("Red zones", RED_ZONES, RED, axes[0]),
+        ("Blue zones", BLUE_ZONES, BLUE, axes[1]),
+    ]
+    for name, zones, color, ax in groups:
+        g = pdf[pdf["zone"].isin(zones)]
+        x = g["current_area"].to_numpy(float)
+        y = g["next_area"].to_numpy(float)
+        ax.scatter(x, y, s=8, alpha=0.22, color=color, edgecolors="none")
+
+        slope, intercept, r2 = fit_line(x, y)
+        if np.isfinite(slope) and np.isfinite(intercept):
+            xs = np.linspace(0, x.max(), 200)
+            ax.plot(xs, slope * xs + intercept, color=INK, linewidth=1.4)
+            ax.plot(xs, xs, color=MUTED, linewidth=0.8, linestyle=(0, (4, 4)))
+            ax.text(
+                0.04, 0.94,
+                f"slope {slope:.2f}   R²  {r2:.2f}",
+                transform=ax.transAxes, ha="left", va="top",
+                fontsize=10, color=INK,
+            )
+        ax.set_title(name, color=color)
+        ax.set_xlabel("Area at day t  (cm²)")
+        ax.set_xlim(0, x.max() * 1.02)
+        ax.set_ylim(0, max(y.max(), x.max()) * 1.02)
+    axes[0].set_ylabel("Area at day t+1  (cm²)")
+    fig.subplots_adjust(wspace=0.12)
+    _save(fig, "e17_zone_transition.png")
+
+
+def fig_spectrum():
+    if not SPECTRA.exists():
+        print(f"no spectra archive at {SPECTRA}; skipping spectrum figure")
+        return
+
+    zone_spectra: dict[int, dict[str, tuple[np.ndarray, np.ndarray]]] = {}
+    with tarfile.open(SPECTRA, "r:gz") as tar:
+        for m in tar.getmembers():
+            mm = re.search(r"zone(\d+)_(red|white|blue)\.txt$", m.name)
+            if not mm:
+                continue
+            zone = int(mm.group(1))
+            color = mm.group(2)
+            data = np.loadtxt(io.BytesIO(tar.extractfile(m).read()), skiprows=1)
+            zone_spectra.setdefault(zone, {})[color] = (data[:, 0], data[:, 1])
+
+    if not zone_spectra:
+        print("no zones parsed from spectra archive; skipping spectrum figure")
+        return
+
+    zone = sorted(zone_spectra.keys())[0]
+    chans = zone_spectra[zone]
+
+    fig, ax = plt.subplots(figsize=(12, 4.8))
+    for color, hex_color, label in [
+        ("blue", BLUE, "blue"),
+        ("white", WHITE_BAR, "white"),
+        ("red", RED, "red"),
+    ]:
+        if color not in chans:
+            continue
+        wl, intensity = chans[color]
+        ax.fill_between(wl, 0, intensity, color=hex_color, alpha=0.22, linewidth=0)
+        ax.plot(wl, intensity, color=hex_color, linewidth=1.6, label=label)
+
+    ax.set_xlabel("Wavelength (nm)")
+    ax.set_ylabel("Intensity")
+    ax.set_yticks([])
+    ax.legend(loc="upper right", ncol=3, columnspacing=1.6, handlelength=1.4)
+    _save(fig, "e17_spectrum.png")
+
+
+if __name__ == "__main__":
+    print(f"output -> {OUT}")
+    fig_plant_area_trajectories()
+    fig_reward_over_time()
+    fig_action_coef()
+    fig_zone_transition()
+    fig_spectrum()
+    print("done")

--- a/slides/scripts/pull_zone_frames.py
+++ b/slides/scripts/pull_zone_frames.py
@@ -1,0 +1,106 @@
+"""
+Pull day-14 (9:30 AM observation) raw and viz frames for all 12 E17 zones.
+
+Authoritative source for each frame: the `image_name` column of each zone's
+processed parquet. Don't guess from filenames or timezone offsets.
+
+Outputs to slides/assets/photos/zones/zone{NN}_{raw,viz}.jpg
+"""
+
+import shutil
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+E17_ROOT = Path("/data/plant-rl/online/E17/P1")
+TARGET_DATE = date(2026, 4, 14)
+OUT = Path(__file__).resolve().parent.parent / "assets" / "photos" / "zones"
+RESIZE = "1600x"
+
+
+def find_zone_dirs() -> dict[int, Path]:
+    """Return {zone_number: zone_dir} for every E17 zone."""
+    zones: dict[int, Path] = {}
+    for zd in E17_ROOT.glob("*/alliance-zone*"):
+        zone = int(zd.name.split("zone")[-1])
+        zones[zone] = zd
+    return dict(sorted(zones.items()))
+
+
+def lookup_raw_name(parquet: Path, day: date) -> str | None:
+    """Return the raw image filename used for the 9:30 observation on `day`."""
+    df = pl.read_parquet(parquet, columns=["time", "plant_id", "image_name"])
+    rows = (
+        df.filter(pl.col("time").dt.date() == pl.lit(day))
+        .unique(subset=["time"])
+        .select("image_name")
+    )
+    if rows.is_empty():
+        return None
+    return rows["image_name"][0]
+
+
+def viz_path_for(zone_dir: Path, zone: int, day: date) -> Path:
+    return (
+        zone_dir
+        / "processed"
+        / "v27"
+        / "visualizations"
+        / f"E17_Z{zone}_{day:%Y-%m-%d}T093000_viz.jpg"
+    )
+
+
+def convert_resize(src: Path, dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["convert", str(src), "-resize", RESIZE, "-quality", "92", str(dst)],
+        check=True,
+    )
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    zones = find_zone_dirs()
+    print(f"Found {len(zones)} zones in {E17_ROOT}")
+
+    misses: list[str] = []
+    for zone, zone_dir in zones.items():
+        zz = f"{zone:02d}"
+        parquet = zone_dir / "processed" / "v27" / f"E17_Z{zone}.parquet"
+        if not parquet.exists():
+            misses.append(f"Z{zone}: no parquet at {parquet}")
+            continue
+
+        raw_name = lookup_raw_name(parquet, TARGET_DATE)
+        if not raw_name:
+            misses.append(f"Z{zone}: no row in parquet for {TARGET_DATE}")
+            continue
+
+        raw_src = zone_dir / "images" / raw_name
+        viz_src = viz_path_for(zone_dir, zone, TARGET_DATE)
+
+        if not raw_src.exists():
+            misses.append(f"Z{zone}: raw missing: {raw_src}")
+            continue
+        if not viz_src.exists():
+            misses.append(f"Z{zone}: viz missing: {viz_src}")
+
+        raw_dst = OUT / f"zone{zz}_raw.jpg"
+        viz_dst = OUT / f"zone{zz}_viz.jpg"
+        convert_resize(raw_src, raw_dst)
+        if viz_src.exists():
+            convert_resize(viz_src, viz_dst)
+        print(f"Z{zone}: raw={raw_src.name}  ->  {raw_dst.name}, {viz_dst.name}")
+
+    if misses:
+        print("\nMisses:")
+        for m in misses:
+            print(" ", m)
+        sys.exit(1 if any("no parquet" in m or "no row" in m or "raw missing" in m for m in misses) else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `slides/scripts/pull_zone_frames.py` — extract zone frames from processed data
- `slides/scripts/make_film_strip.py` — build film-strip composites
- `slides/scripts/make_slide_figures.py` — regenerate presentation figures

Assets excluded (local-only).

## Test plan
- [ ] Run scripts against a known parquet path and verify output paths

Made with [Cursor](https://cursor.com)