### PR TITLE
feat: E18 policy labels and VISION_VERSION bump

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 VERSION = "v27"
-VISION_VERSION = "v6"
+VISION_VERSION = "v7"
 
 GOOD_ZONE_DAYS = {
     "E11/zone1": [1, 2, 3, 4, 5, 6, 7, 9, 10, 11],
@@ -71,6 +71,21 @@ GOOD_ZONE_DAYS = {
     "E16/zone11": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
     "E16/zone12": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
 }
+
+E18_POLICY_MAP = {
+    1: "SequencePowerLawRamp",
+    2: "SequenceParabolic",
+    3: "ConstantLow",
+    4: "SequenceSeventyPercentRamp",
+    5: "SequenceLateRamp",
+    6: "SequenceBlueToRedLate",
+    7: "SequenceBlueToRedEarly",
+    8: "ConstantBlue",
+    9: "SequenceRedToBlueEarly",
+    10: "SequenceRedToBlueLate",
+    11: "Constant",
+}
+
 TIMEZONE = "America/Edmonton"
 tzinfo = ZoneInfo(TIMEZONE)
 RED = np.array([9.71409574, 34.97074468, 4.01515957, 0.0, 56.3, 6.13067376])

--- a/transforms/attributes.py
+++ b/transforms/attributes.py
@@ -1,6 +1,8 @@
 from datetime import date
 import polars as pl
 
+from config import E18_POLICY_MAP
+
 
 EXPERIMENT_EVENTS = {
     7: {
@@ -200,6 +202,8 @@ def get_agent_name(df: pl.DataFrame) -> pl.DataFrame:
             .then(pl.lit("BlueBlue"))
             .otherwise(pl.lit("Other"))
         )
+        .when(pl.col("experiment") == 18)
+        .then(pl.col("zone").replace_strict(E18_POLICY_MAP, default="Other"))
         .otherwise(pl.lit("Other"))
         .alias("agent")
     )


### PR DESCRIPTION
## Summary
- Add `E18_POLICY_MAP` to `config.py` mapping zone numbers to policy names
- Wire `E18_POLICY_MAP` into `get_agent_name()` in `transforms/attributes.py` via `replace_strict`
- Bump `VISION_VERSION` v6 → v7

## Test plan
- [ ] Verify `get_agent_name()` returns correct policy names for E18 zones 1–11