### PR TITLE
feat: E18 daily subsample pipeline and parameterized Minari export

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,6 +89,11 @@ E18_POLICY_MAP = {
 TIMEZONE = "America/Edmonton"
 tzinfo = ZoneInfo(TIMEZONE)
 RED = np.array([9.71409574, 34.97074468, 4.01515957, 0.0, 56.3, 6.13067376])
+
+# Balanced-white spectrum at 100 PPFD — mirrors plant-rl BALANCED_ACTION_100.
+# IntensityAction: commanded_action = BALANCED_ACTION_100 * intensity
+BALANCED_ACTION_105 = np.array([19.5, 71.53, 7.82, 0.0, 6.15, 0.0])
+BALANCED_ACTION_100 = BALANCED_ACTION_105 / BALANCED_ACTION_105[:5].sum() * 100.0
 WHITE = np.array([19.6875, 70.875, 8.1375, 0.0, 6.3, 12.425])
 BLUE = np.array([69.6875, 29.33653846, 3.36826923, 0.0, 2.60769231, 5.14294872])
 

--- a/create_minari_dataset.py
+++ b/create_minari_dataset.py
@@ -15,17 +15,43 @@ logging.basicConfig(level=logging.INFO)
 
 
 def main():
+    default_dir = Path(f"/data/plant-rl/offline/{VERSION}/")
+    default_input = default_dir / f"mixed-{VERSION}.parquet"
+
     parser = argparse.ArgumentParser(description="Convert processed dataset to Minari.")
     parser.add_argument(
         "--input-dir",
         type=str,
-        default=f"/data/plant-rl/offline/{VERSION}/",
-        help="Directory containing the RL filtered dataset",
+        default=str(default_dir),
+        help="Directory containing the RL filtered dataset (used as default for --input "
+        "and normalization-stats lookup).",
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        default=None,
+        help=f"Path to the input parquet file. "
+        f"Default: <input-dir>/mixed-{{VERSION}}.parquet",
+    )
+    parser.add_argument(
+        "--name",
+        type=str,
+        default="mixed",
+        help="Base name for the Minari dataset IDs. "
+        "Emits plant-data/<name>-{VERSION} and plant-data/<name>-all-{VERSION}. "
+        "Default: 'mixed'.",
+    )
+    parser.add_argument(
+        "--action",
+        choices=["coef", "intensity"],
+        default="coef",
+        help="Action representation. 'coef' = 3-dim [red_coef, white_coef, blue_coef] "
+        "(default). 'intensity' = 1-dim scalar from the 'intensity' column.",
     )
     args = parser.parse_args()
 
     input_dir = Path(args.input_dir)
-    input_path = input_dir / f"mixed-{VERSION}.parquet"
+    input_path = Path(args.input) if args.input else input_dir / f"mixed-{VERSION}.parquet"
 
     logging.info(f"Loading dataset from {input_path}")
 
@@ -35,15 +61,36 @@ def main():
         logging.error(f"File not found: {input_path}. Please run join_zones.py first.")
         return
 
-    stats = load_normalization_stats(input_dir / f"normalization-stats-{VERSION}.json")
+    # Locate matching normalization-stats file
+    stats_stem = input_path.stem  # e.g. "mixed-v27" or "mixed-e18-daily-v27"
+    stats_path = input_dir / f"normalization-stats-{stats_stem}.json"
+    if not stats_path.exists():
+        stats_path = input_path.parent / f"normalization-stats-{stats_stem}.json"
+    # Legacy naming: mixed-v27.parquet paired with normalization-stats-v27.json
+    if not stats_path.exists() and stats_stem == f"mixed-{VERSION}":
+        for candidate in (
+            input_dir / f"normalization-stats-{VERSION}.json",
+            input_path.parent / f"normalization-stats-{VERSION}.json",
+        ):
+            if candidate.exists():
+                stats_path = candidate
+                break
+    logging.info(f"Loading normalization stats from {stats_path}")
+    stats = load_normalization_stats(stats_path)
+
+    # Resolve action columns
+    action_cols = None
+    if args.action == "intensity":
+        action_cols = ["intensity"]
 
     df = df.filter(~pl.col("outlier"))
     df_filtered = df.filter(pl.col("day") < 15)
     df = transform_terminal(df)
 
     def create_dataset(df: pl.DataFrame, name: str):
-        mock_env = MockEnv(df, stats, COLS)
+        mock_env = MockEnv(df, stats, COLS, action_cols=action_cols)
         env = DataCollector(mock_env, record_infos=True)
+        dataset_id = f"plant-data/{name}-{VERSION}"
 
         # Run episodes until environment indicates all data has been processed
         logging.info("Generating Minari dataset...")
@@ -57,36 +104,48 @@ def main():
                 if terminated or truncated:
                     break
 
-        dataset = env.create_dataset(
-            dataset_id=f"plant-data/{name}-{VERSION}",
-            algorithm_name="None",
-            code_permalink="https://github.com/steventango/plant-data",
-            author="Steven Tang",
-            author_email="stang5@ualberta.ca",
-        )
+        try:
+            dataset = env.create_dataset(
+                dataset_id=dataset_id,
+                algorithm_name="None",
+                code_permalink="https://github.com/steventango/plant-data",
+                author="Steven Tang",
+                author_email="stang5@ualberta.ca",
+            )
+        except ValueError as exc:
+            if "already exists" in str(exc):
+                logging.info(f"Skipping existing dataset: {dataset_id}")
+                return
+            raise
 
         print(f"Dataset created: {dataset.id}")
 
-    gkf = GroupKFold(n_splits=5)
+    # GroupKFold cross-validation splits (skipped when there are too few groups)
+    n_splits = 5
     groups_df = df.select(["experiment", "zone"]).with_columns(
         pl.concat_str([pl.col("experiment"), pl.col("zone")], separator="-").alias(
             "group"
         )
     )
     groups = groups_df["group"].to_numpy()
+    n_groups = len(set(groups.tolist()))
 
-    logging.info("Generating GroupKFold datasets...")
-    for fold, (train_idx, val_idx) in enumerate(gkf.split(df, groups=groups)):
-        logging.info(f"Processing Fold {fold}...")
+    if n_groups >= n_splits:
+        gkf = GroupKFold(n_splits=n_splits)
+        logging.info("Generating GroupKFold datasets...")
+        for fold, (train_idx, val_idx) in enumerate(gkf.split(df, groups=groups)):
+            logging.info(f"Processing Fold {fold}...")
+            df_train = df[train_idx]
+            df_val = df[val_idx]
+            create_dataset(df_train, f"{args.name}-all-fold{fold}-train")
+            create_dataset(df_val, f"{args.name}-all-fold{fold}-val")
+    else:
+        logging.info(
+            f"Skipping GroupKFold (n_groups={n_groups} < n_splits={n_splits})."
+        )
 
-        df_train = df[train_idx]
-        df_val = df[val_idx]
-
-        create_dataset(df_train, f"mixed-all-fold{fold}-train")
-        create_dataset(df_val, f"mixed-all-fold{fold}-val")
-
-    create_dataset(df_filtered, "mixed")
-    create_dataset(df, "mixed-all")
+    create_dataset(df_filtered, args.name)
+    create_dataset(df, f"{args.name}-all")
 
 
 if __name__ == "__main__":

--- a/generate_mixed_e18_daily.sh
+++ b/generate_mixed_e18_daily.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Generate the E18 Zones 1,3,4,11 daily (9:00 AM local) mixed dataset with intensity action.
+# Reuses the existing v27 processed parquets (no vision pipeline needed).
+
+set -euo pipefail
+
+uv run python join_zones.py \
+    --root-dir /data/plant-rl/online \
+    --experiments 18 \
+    --zones 1,3,4,11 \
+    --subsample daily \
+    --output-name mixed-e18-daily-v27
+
+uv run python create_minari_dataset.py \
+    --input /data/plant-rl/offline/v27/mixed-e18-daily-v27.parquet \
+    --name visu \
+    --action intensity

--- a/join_zones.py
+++ b/join_zones.py
@@ -1,72 +1,125 @@
 import argparse
 import logging
-from datetime import time
+import math
+import re
 from pathlib import Path
 
 import polars as pl
 
-from config import VERSION, TIMEZONE, tzinfo
+from config import VERSION, TIMEZONE
 from transforms import (
     transform_action_traces,
     transform_outlier_detection,
     transform_pca,
     transform_umap,
-    # transform_reward,
-    # transform_state,
 )
 from transforms.normalization import (
     compute_normalization_stats,
     save_normalization_stats,
 )
+from transforms.states import transform_energy, transform_log_clean_area
 
 logging.basicConfig(level=logging.INFO)
 
 
-def subsample(df: pl.DataFrame, type: str = "daily") -> pl.DataFrame:
-    if type == "daily":
-        # TODO: transform action by averaging over the day between 9:30 and 20:30
-        # df = df.filter(
-        #     (pl.col("time").dt.time() >= time(9, 30, tzinfo=tzinfo))
-        #     & (pl.col("time").dt.time() < time(20, 30, tzinfo=tzinfo))
-        # )
-        # df = df.with_columns(
-        #     pl.col("action")
-        #     .mean()
-        #     .over("experiment", "zone", "plant_id", "day")
-        #     .alias("action"),
-        # )
-        df_daily = df.filter(pl.col("time").dt.time() == time(9, 30, tzinfo=tzinfo))
-        df_daily = df_daily.with_columns(
-            (pl.col("clean_area") + 1).log().alias("log_clean_area")
-        )
-        df_daily = df_daily.with_columns(
-            pl.col("log_clean_area")
-            .shift(1)
-            .over("experiment", "zone", "plant_id")
-            .alias("prev_log_clean_area"),
-        )
-        df_daily = df_daily.with_columns(
-            (pl.col("log_clean_area") - pl.col("prev_log_clean_area")).alias("reward"),
-        )
-        df_daily = df_daily.drop("prev_log_clean_area")
-        df_daily = transform_action_traces(df_daily)
-        df_daily = transform_outlier_detection(df_daily, q1=0.01, q2=0.99)
-        df_daily = df_daily.with_columns(
+def _parse_exp_zone(path: Path) -> tuple[int, int] | tuple[None, None]:
+    """Extract (experiment, zone) from a processed parquet filename like E18_Z11.parquet."""
+    m = re.match(r"E(\d+)_Z(\d+)", path.stem)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    return None, None
+
+
+def subsample_daily(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Recompute daily-cadence derived columns after the per-file 9:00-local filter.
+
+    The processed parquets carry 4-hourly energy and reward values; after
+    restricting to the single 9:00-local row per day we need to:
+      - recompute energy  as cumulative_energy diff over the daily grid
+      - recompute log_clean_area
+      - recompute reward  as Δ log_clean_area over experiment/zone/plant_id
+      - recompute action traces at the daily cadence
+      - recompute outlier flags
+      - recompute truncated flag (next row not exactly +1 day)
+    """
+    df = df.sort("experiment", "zone", "plant_id", "time")
+
+    # Per-day energy: difference of cumulative_energy on the daily grid
+    df = transform_energy(df)
+
+    # Null out energy when the next sample is not exactly +1 day (cross-gap interval).
+    # imaging_gap anchor rows are still present here so that day1's next is day2_ghost
+    # (1-day diff) rather than day3 (2-day diff), giving the correct energy for day1.
+    if "energy" in df.columns:
+        df = df.with_columns(
             pl.col("time")
             .shift(-1)
             .over("experiment", "zone", "plant_id")
-            .alias("next_time"),
+            .alias("_next_time"),
         )
-        df_daily = df_daily.with_columns(
-            (
-                pl.col("next_time").is_not_null()
-                & (pl.col("next_time") != pl.col("time") + pl.duration(days=1))
-            ).alias("truncated")
+        df = df.with_columns(
+            pl.when(
+                pl.col("_next_time").is_null()
+                | (pl.col("_next_time") - pl.col("time") != pl.duration(days=1))
+            )
+            .then(pl.lit(None, dtype=pl.Float64))
+            .otherwise(pl.col("energy"))
+            .alias("energy"),
         )
-        df_daily = df_daily.drop("next_time")
-        return df_daily
-    else:
-        raise ValueError(f"Unknown subsample type: {type}")
+        df = df.drop("_next_time")
+
+    # Drop imaging-gap anchor rows: they served their purpose for energy anchoring.
+    if "imaging_gap" in df.columns:
+        df = df.filter(~pl.col("imaging_gap")).drop("imaging_gap")
+
+    # log_clean_area
+    df = transform_log_clean_area(df)
+
+    # reward = Δ log_clean_area per plant trajectory
+    df = df.with_columns(
+        pl.col("log_clean_area")
+        .shift(1)
+        .over("experiment", "zone", "plant_id")
+        .alias("prev_log_clean_area"),
+        pl.col("time")
+        .shift(1)
+        .over("experiment", "zone", "plant_id")
+        .alias("_prev_time"),
+    )
+    df = df.with_columns(
+        pl.when(
+            pl.col("_prev_time").is_null()
+            | (pl.col("time") - pl.col("_prev_time") != pl.duration(days=1))
+        )
+        .then(pl.lit(None, dtype=pl.Float64))
+        .otherwise(pl.col("log_clean_area") - pl.col("prev_log_clean_area"))
+        .alias("reward"),
+    )
+    df = df.drop("prev_log_clean_area", "_prev_time")
+
+    # Recompute action traces at daily cadence
+    df = transform_action_traces(df)
+
+    # Outlier detection on the new daily values
+    df = transform_outlier_detection(df, q1=0.01, q2=0.99)
+
+    # truncated: next row is not exactly +1 day
+    df = df.with_columns(
+        pl.col("time")
+        .shift(-1)
+        .over("experiment", "zone", "plant_id")
+        .alias("next_time"),
+    )
+    df = df.with_columns(
+        (
+            pl.col("next_time").is_not_null()
+            & (pl.col("next_time") != pl.col("time") + pl.duration(days=1))
+        ).alias("truncated")
+    )
+    df = df.drop("next_time")
+
+    return df
 
 
 def main():
@@ -83,14 +136,65 @@ def main():
         default=f"/data/plant-rl/offline/{VERSION}/",
         help="Directory to save output files",
     )
+    parser.add_argument(
+        "--experiments",
+        type=str,
+        default=None,
+        help="Comma-separated experiment IDs to include (e.g. '18'). Default: all.",
+    )
+    parser.add_argument(
+        "--zones",
+        type=str,
+        default=None,
+        help="Comma-separated zone IDs to include (e.g. '1,3,4,11'). Default: all.",
+    )
+    parser.add_argument(
+        "--subsample",
+        choices=["none", "daily"],
+        default="none",
+        help="Temporal subsampling to apply after joining. "
+        "'daily' retains the 9:00 AM local-time row per day and recomputes "
+        "energy/reward/traces/truncated for the daily cadence.",
+    )
+    parser.add_argument(
+        "--output-name",
+        type=str,
+        default=None,
+        help=f"Base name for output files (default: mixed-{{VERSION}}). "
+        f"Files written: <name>.parquet, normalization-stats-<name>.json.",
+    )
     args = parser.parse_args()
 
     root_dir = Path(args.root_dir)
     output_dir = Path(args.output_dir)
 
+    # Parse experiment/zone filters
+    exp_filter: set[int] | None = None
+    zone_filter: set[int] | None = None
+    if args.experiments:
+        exp_filter = {int(e) for e in args.experiments.split(",")}
+    if args.zones:
+        zone_filter = {int(z) for z in args.zones.split(",")}
+
+    output_name = args.output_name if args.output_name else f"mixed-{VERSION}"
+
     # Load all intermediate zone files recursively
     logging.info(f"Searching for processed files in {root_dir}...")
     files = sorted(root_dir.rglob(f"processed/{VERSION}/*.parquet"))
+
+    # Apply experiment/zone filter by parsing filenames
+    if exp_filter is not None or zone_filter is not None:
+        filtered = []
+        for f in files:
+            exp, zone = _parse_exp_zone(f)
+            if exp is None:
+                continue
+            if exp_filter is not None and exp not in exp_filter:
+                continue
+            if zone_filter is not None and zone not in zone_filter:
+                continue
+            filtered.append(f)
+        files = filtered
 
     if not files:
         logging.error(f"No processed files found in {root_dir}")
@@ -111,6 +215,14 @@ def main():
             + (["patch_features"] if "patch_features" in lf.columns else [])
         )
 
+        if args.subsample == "daily":
+            # Filter to 9:00 AM local-time rows (before Edmonton tz conversion).
+            # E18 local tz is Etc/GMT-2; 9:00 local = 01:00 Edmonton.
+            # Filtering on local hour/minute is robust across all zones.
+            lf = lf.filter(
+                (pl.col("time").dt.hour() == 9) & (pl.col("time").dt.minute() == 0)
+            )
+
         # Make image_path absolute and point to segment images
         prefix = str(file.parent)
         lf = lf.with_columns(
@@ -126,15 +238,87 @@ def main():
         .collect(engine="streaming")
     )
 
-    # Apply outlier detection on full dataset before saving
-    df = transform_outlier_detection(df, q1=0.01, q2=0.99)
+    if args.subsample == "daily":
+        logging.info("Recomputing daily-cadence derived columns...")
+        df = subsample_daily(df)
+
+        # Compute scalar intensity: a = sum(action channels) / 100
+        # Follows plant-rl IntensityAction: commanded = BALANCED_ACTION_100 * a
+        action_cols = [f"action.{i}" for i in range(6)]
+        available_action_cols = [c for c in action_cols if c in df.columns]
+        if available_action_cols:
+            df = df.with_columns(
+                (sum(pl.col(c) for c in available_action_cols) / 100.0).alias(
+                    "intensity"
+                )
+            )
+            # Drop rows where lights were off (intensity == 0 at 9:00 = bad data)
+            before = df.height
+            df = df.filter(pl.col("intensity") > 0)
+            dropped = before - df.height
+            if dropped:
+                logging.warning(f"Dropped {dropped} zero-intensity rows (lights off at 9:00 AM)")
+
+        # ----- Energy-reward columns -----
+        # Reference constants derived from Zone 11 (Constant baseline)
+        z11_df = df.filter(pl.col("zone") == 11)
+        if z11_df.is_empty() or z11_df["energy"].drop_nulls().len() == 0:
+            logging.warning("Zone 11 not in dataset; using dataset-wide energy/reward baselines")
+            e_const = float(df["energy"].drop_nulls().mean())
+            r_const = float(df["reward"].drop_nulls().mean())
+        else:
+            e_const = float(z11_df["energy"].drop_nulls().mean())
+            r_const = float(z11_df["reward"].drop_nulls().mean())
+        max_energy = float(df["energy"].drop_nulls().max())
+        r_gate = 0.95 * r_const
+        fail_penalty = 2.0 * max_energy
+        log_e_const = math.log(e_const)
+        logging.info(
+            f"Schema constants: e_const={e_const:.1f} Wh, r_const={r_const:.5f}, "
+            f"r_gate={r_gate:.5f}, max_energy={max_energy:.1f} Wh, fail_penalty={fail_penalty:.1f}"
+        )
+
+        # Rename daily Δ log_clean_area: reward → area_reward
+        df = df.rename({"reward": "area_reward"})
+
+        # Schema A: energy_reward_schema_a_β = (β / N_STEPS) · (log(energy) − log(e_const))
+        # Divided by N_STEPS=14 so that summing over an episode gives the same
+        # magnitude as the episode-level formula β · log(E_total / E_const_total).
+        N_STEPS = 14
+        for beta in [0.5, 1.0, 2.0, 4.0, 8.0]:
+            col_name = f"energy_reward_schema_a_{beta:g}"
+            df = df.with_columns(
+                pl.when(pl.col("energy").is_not_null() & (pl.col("energy") > 0))
+                .then((pl.col("energy").log() - log_e_const) * (beta / N_STEPS))
+                .otherwise(None)
+                .alias(col_name)
+            )
+
+        # Schema B: gate on each step's area_reward vs Zone 11 baseline
+        # passed (area_reward ≥ 0.95 · r_const): pay energy; failed: pay 2 · max_energy
+        df = df.with_columns(
+            pl.when(pl.col("area_reward").is_null())
+            .then(None)
+            .when(pl.col("area_reward") >= r_gate)
+            .then(pl.col("energy"))
+            .otherwise(pl.lit(fail_penalty))
+            .alias("energy_reward_schema_b")
+        )
+
+        # Combined RL reward: area growth minus energy cost (Schema A, β=1)
+        df = df.with_columns(
+            (pl.col("area_reward") - pl.col("energy_reward_schema_a_1")).alias("reward")
+        )
+    else:
+        # Apply outlier detection on full dataset before saving (original behaviour)
+        df = transform_outlier_detection(df, q1=0.01, q2=0.99)
 
     pl.Config.set_tbl_rows(20)
     print(
         df.filter(
-            (pl.col("experiment") == 11)
-            & (pl.col("zone") == 1)
-            & (pl.col("plant_id") == 0)
+            (pl.col("experiment") == df["experiment"].min())
+            & (pl.col("zone") == df["zone"].min())
+            & (pl.col("plant_id") == df["plant_id"].min())
         ).select(
             "wall_time", "time", "clean_area", "reward", "nodata", "outlier", "valid"
         )
@@ -146,14 +330,27 @@ def main():
     # Save to parquet
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Save the full continuous dataset
-    path = output_dir / f"mixed-{VERSION}.parquet"
-    logging.info(f"Saving full dataset to {path}")
+    path = output_dir / f"{output_name}.parquet"
+    logging.info(f"Saving dataset to {path}")
     df.write_parquet(path)
 
+    stats_path = output_dir / f"normalization-stats-{output_name}.json"
     full_stats = compute_normalization_stats(df)
-    full_stats_path = output_dir / f"normalization-stats-{VERSION}.json"
-    save_normalization_stats(full_stats, full_stats_path)
+
+    # Add stats for any action columns not in COLS (e.g. intensity, energy_reward_*)
+    extra_reward_cols = [f"energy_reward_schema_a_{b:g}" for b in [0.5, 1.0, 2.0, 4.0, 8.0]]
+    for extra_col in ["intensity", "area_reward", "energy_reward_schema_b"] + extra_reward_cols:
+        if extra_col in df.columns and extra_col not in full_stats:
+            col_series = df[extra_col].drop_nulls().drop_nans()
+            if col_series.len() > 0:
+                full_stats[extra_col] = {
+                    "min": float(col_series.min()),
+                    "max": float(col_series.max()),
+                    "mean": float(col_series.mean()),
+                    "std": float(col_series.std()),
+                }
+
+    save_normalization_stats(full_stats, stats_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `join_zones.py` `--subsample daily`: retain the 9:00 AM local row per day and recompute energy (cumulative diff), log_clean_area, reward (Δ log_clean_area, nulled on gaps), action traces, outlier flags, and `truncated` at daily cadence; drop imaging-gap anchor rows after energy anchoring
- `join_zones.py` `--experiments` / `--zones`: filter by ID without touching other zones
- `join_zones.py` `--output-name`: custom output filename stem with matching normalization-stats file
- Daily mode computes a scalar `intensity` action and energy-reward schemas A (β ∈ {0.5,1,2,4,8}) and B (gate on Zone 11 baseline)
- `config.py`: add `BALANCED_ACTION_105`/`100` constants (mirrors plant-rl)
- `create_minari_dataset.py`: `--input`, `--name`, `--action intensity`; robust stats-file resolution; skip GroupKFold when groups < splits; skip existing datasets
- `generate_mixed_e18_daily.sh`: convenience script for E18 zones 1, 3, 4, 11

**Stacked on:** feat/mockenv-hardening

## Test plan
- [ ] `./generate_mixed_e18_daily.sh` (requires processed parquets on disk)
- [ ] `uv run python create_minari_dataset.py --input /data/plant-rl/offline/v27/mixed-e18-daily-v27.parquet --name visu --action intensity`